### PR TITLE
:bug: fixing a bug with saturated pixels and tpf meta data

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -696,6 +696,7 @@ class Machine(object):
             vmin=0.5,
             vmax=1.5,
             cmap="coolwarm",
+            rasterized=True,
         )
         ax[0, 1].scatter(
             dx[k2],
@@ -705,9 +706,17 @@ class Machine(object):
             vmin=0.5,
             vmax=1.5,
             cmap="coolwarm",
+            rasterized=True,
         )
         ax[1, 0].scatter(
-            dx[k1], dy[k1], c=model[0][k1], s=3, vmin=0.5, vmax=1.5, cmap="coolwarm"
+            dx[k1],
+            dy[k1],
+            c=model[0][k1],
+            s=3,
+            vmin=0.5,
+            vmax=1.5,
+            cmap="coolwarm",
+            rasterized=True,
         )
         ax[1, 1].scatter(
             dx[k2],
@@ -717,6 +726,7 @@ class Machine(object):
             vmin=0.5,
             vmax=1.5,
             cmap="coolwarm",
+            rasterized=True,
         )
         ax[0, 0].set(title="Data First Cadence", ylabel=r"$\delta y$")
         ax[0, 1].set(title="Data Last Cadence")
@@ -952,7 +962,14 @@ class Machine(object):
             n_phi_knots=self.n_phi_knots,
         )
         im = ax[1, 1].scatter(
-            phi, r, c=A.dot(self.psf_w), cmap="viridis", vmin=-3, vmax=-1, s=3
+            phi,
+            r,
+            c=A.dot(self.psf_w),
+            cmap="viridis",
+            vmin=-3,
+            vmax=-1,
+            s=3,
+            rasterized=True,
         )
         ax[1, 1].set(
             xlabel=r"$\phi$ [$^\circ$]",
@@ -963,7 +980,14 @@ class Machine(object):
         )
 
         im = ax[1, 0].scatter(
-            dx, dy, c=A.dot(self.psf_w), cmap="viridis", vmin=-3, vmax=-1, s=3
+            dx,
+            dy,
+            c=A.dot(self.psf_w),
+            cmap="viridis",
+            vmin=-3,
+            vmax=-1,
+            s=3,
+            rasterized=True,
         )
         ax[1, 0].set(
             xlabel=r'$\delta x$ ["]',

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -380,9 +380,16 @@ class TPFMachine(Machine):
             SkyCoord(tpf_meta["ra"], tpf_meta["dec"], unit="deg"),
             SkyCoord(np.asarray(sources[["ra", "dec"]]), unit="deg"),
         )
-        match = (sep < 1 * u.arcsec) & np.asarray(
-            np.abs(sources["phot_g_mean_mag"][idx] - tpf_meta["tpfmag"]) < 0.25
+        match = (sep < 1 * u.arcsec) & (
+            np.abs(
+                np.asarray(sources["phot_g_mean_mag"][idx])
+                - np.asarray(
+                    [t if t is not None else np.nan for t in tpf_meta["tpfmag"]]
+                )
+            )
+            < 0.25
         )
+
         sources["tpf_id"] = None
         sources.loc[idx[match], "tpf_id"] = np.asarray(tpf_meta["targetid"])[match]
 
@@ -484,9 +491,9 @@ def _parse_TPFs(tpfs, **kwargs):
     sat_mask = []
     for tpf in tpfs:
         # Keplerish saturation limit
-        saturated = np.nanmax(tpf.flux, axis=0).value > 1.2e5
+        saturated = np.nanmax(tpf.flux, axis=0).T.value > 1.4e5
         saturated = np.hstack(
-            (np.gradient(saturated.astype(float))[0] != 0) | saturated
+            (np.gradient(saturated.astype(float))[1] != 0) | saturated
         )
         sat_mask.append(np.hstack(saturated))
     sat_mask = np.hstack(sat_mask)


### PR DESCRIPTION
There are a few bugs in the new implementation

1) The saturated pixel mask masks the wrong entries
2) If there are "none" values in the tpfs for the KEPMAG keyword, the machine breaks