### PR TITLE
[Do Not Merge] Sketch of potential refactor

### DIFF
--- a/src/psfmachine/ffi.py
+++ b/src/psfmachine/ffi.py
@@ -1,0 +1,118 @@
+"""Classes for working with FFI data"""
+from .utils import get_gaia_sources
+from .machine import Machine
+
+
+def FFIMachine(Machine):
+    """Subclass of Machine for working with FFI data"""
+
+    # Probably don't need a very new init function over Machine.
+    def __init__(self, channel=channel, quarter=quarter, **kwargs):
+        super().__init__(**kwargs)
+        self.channel = channel
+        self.quarter = quarter
+
+    def __repr__(self):
+        return f"FFIMachine (N sources, N times, N pixels): {self.shape}"
+
+    @staticmethod
+    def from_file(self, fname):
+        """Reads data from files and initiates a new class...
+
+        Parameters
+        ----------
+        fname : str
+            Filename"""
+        sources = self._get_sources()
+        time, flux, flux_err, ra, dec, column, row = self._load_file()
+        raise NotImplementedError
+        return FFIMachine(
+            time=times,
+            flux=flux,
+            flux_err=flux_err,
+            ra=ra,
+            dec=dec,
+            sources=sources,
+            column=column,
+            row=row,
+        )
+
+    def save_shape_model(self, output=None):
+        """Saves the weights of a PRF fit to a file
+
+        Parameters
+        ----------
+        output : str, None
+            Output file name. If None, one will be generated.
+        """
+        raise NotImplementedError
+
+    def load_shape_model(self):
+        """Loads a PRF"""
+        raise NotImplementedError
+
+    def save_flux_values(self, output=None, format="feather"):
+        """Saves the flux values of all sources to a file
+
+        Parameters
+        ----------
+        output : str, None
+            Output file name. If None, one will be generated.
+        format : str
+            Something like a format, maybe feather, csv, fits?
+        """
+        raise NotImplementedError
+
+    def _background_removal_functions(self):
+        """kepler-apertures probably used some background removal functions, e.g. mean filter, fine to subclass astropy here"""
+        raise NotImplementedError
+
+    def _masking_functions(self):
+        """kepler-apertures probably needed some bespoke masking functions?"""
+        raise NotImplementedError
+
+    def _get_sources(self):
+        """Gets sources in a tiled manner, update and/or use existing query functions?"""
+        raise NotImplementedError
+
+    def _load_file(self):
+        """Helper function to load file?"""
+
+        # Have to do some checks here that it's the right kind of data.
+        #  We could loosen these checks in future.
+        if hdu[0].header["MISSION"] is "KEPLER":
+            pass
+        if hdu[0].header["MISSION"] is "K2":
+            pass
+        if hdu[0].header["MISSION"] is "TESS":
+            pass
+
+        raise NotImplementedError
+
+
+def _buildKeplerPRFDatabase(fnames):
+    """Procedure to build the database of Kepler PRF shape models.
+
+    Parameters
+    ---------
+    fnames: list of str
+        List of filenames for Kepler FFIs.
+    """
+
+    # This proceedure should be stored as part of the module, because it will
+    # be vital for reproducability.
+
+    # 1. Do some basic checks on FFI files that they are Kepler FFIs, and that
+    # all 53 are present, all same channel etc.
+
+    # 2. Iterate through files
+    for fname in fnames:
+        f = FFIMachine.from_file(fname, HARD_CODED_PARAMETERS)
+        f.build_shape_model()
+        f.fit_model()
+
+        output = (
+            PACKAGEDIR
+            + f"src/psfmachine/data/q{self.quarter}_ch{self.channel}_{params}.csv"
+        )
+        f.save_shape_model(output=output)

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -922,7 +922,7 @@ class Machine(object):
         self.mean_model = mean_model
 
     def plot_shape_model(self, radius=20):
-        """ Diagnostic plot of shape model..."""
+        """Diagnostic plot of shape model..."""
 
         mean_f = np.log10(
             self.uncontaminated_source_mask.astype(float)

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -85,7 +85,48 @@ class TPFMachine(Machine):
     def __repr__(self):
         return f"TPFMachine (N sources, N times, N pixels): {self.shape}"
 
-    def fit_lightcurves(self, plot=False, fit_va=True, iter_negative=True):
+    def load_shape_model(self):
+        """
+        Loads a PRF shape model from files, based on FFI models.
+        """
+
+        # Needs to find the appropriate FFI model from database.
+
+        # Needs to set all the relevant matrices
+        # Machine needs to end up in the same state as if I had just run
+        # self.build_shape_model
+        raise NotImplementedError
+
+    def save_shape_model(self, output=None):
+        """Saves the weights of a PRF fit to a file
+
+        Parameters
+        ----------
+        output : str, None
+            Output file name. If None, one will be generated.
+        """
+        raise NotImplementedError
+
+    def _build_apertures(self):
+        """Uses shape model to build apertures for each source in each TPF"""
+        raise NotImplementedError
+
+    def get_SAP_lightcurves(self):
+        """Builds apertures, and extracts light curves from TPFs"""
+
+        # Build SAP photometry
+
+        # List of SAP light curves
+        self.sap_lcs = []
+
+        # Some of the old PSF get_lightcurves function should be reused or augmented
+        # to either build ONE light curve with both PSF photometry and SAP photometry,
+        # or create an analogous light curve with SAP flux.
+        raise NotImplementedError
+
+    def get_PRF_lightcurves(
+        self, plot=False, fit_va=True, iter_negative=True, recalculate_prf_shape=False
+    ):
         """
         Fit the sources inside the TPFs passed to `TPFMachine`.
 
@@ -108,9 +149,12 @@ class TPFMachine(Machine):
             If iter_negative is True, PSFmachine will run up to 3 times, clipping out
             any negative targets each round.
         """
-
-        self.build_shape_model(plot=plot)
+        if recalculate_prf_shape:
+            self.build_shape_model(plot=plot)
+        else:
+            self.load_shape_model()
         self.build_time_model(plot=plot)
+
         self.fit_model(fit_va=fit_va)
         if iter_negative:
             # More than 2% negative cadences
@@ -124,6 +168,7 @@ class TPFMachine(Machine):
                 if idx >= 3:
                     break
 
+        # This should be a helper function so SAP light curves can be added here.
         self.lcs = []
         for idx, s in self.sources.iterrows():
             ldx = np.where([idx in s for s in self.tpf_meta["sources"]])[0][0]

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -86,3 +86,20 @@ def test_parse_TPFs():
 def test_from_TPFs():
     c = TPFMachine.from_TPFs(tpfs)
     assert isinstance(c, Machine)
+
+
+# Test some use cases:
+@pytest.mark.remote_data
+def test_use_cases():
+    c = TPFMachine.from_TPFs(tpfs[0])
+    # Not sure about this API
+    c.get_SAP_lightcurves()
+    assert isinstance(c.sap_lcs, lk.LightCurve)
+
+    # I want to be able to get a PRF light curve from a single TPF
+    # Because I want the PRF model to be loaded from FFIs
+    c.get_PRF_lightcurves()
+    assert isinstance(c.lcs, lk.LightCurve)
+
+    # I think I want a single set of lcs...where the default extention is
+    # prf photometry, but SAP photometry (at different apers) are in another extension too...?


### PR DESCRIPTION
I think this is a rough sketch of what we need in PSF machine, benefitting from `kepler-apertures`. Porting the capabilities we like from `kepler-apertures` to `psfmachine` will mean we only have to maintain one package. `kepler-apertures` is in a great shape for us to do this merge. 

Some key thoughts:
* We probably need an FFI class
* We need a good ability to save/load PRF models in the `TPFMachine` class
* We probably don't need a superstamp class, we can probably make a proceedure that uses the FFI machine for that.
* We have to watch out for where we can be reasonably generic and allow TESS data, and where we need to stop users adding tess data (for now)
* I haven't included any diagnostic plots, but I think those would be great.
* I really want the functionality to be able to do something like

```python
tpm = psf.TPFMachine.from_tpfs(tpf)
tpm.get_lightcurves()
```

which would populate a `tpm.lcs` attribute (or something similar) with `lk.LightCurve` objects, each of which contains the PRF photometry and the SAP photometry. 

Crucially, I don't want it to fit anything, I just want to load the stored weight files and apply them really fast.