### PR TITLE
tiled query

### DIFF
--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -135,15 +135,18 @@ def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
             )
             if not _in.any():
                 continue
-            # get the center coord of the query and radius 6th decimal (10 miliarcsec)
-            # to avoid not catching get_gaia_sources() due to floating point error.
+            # get the center coord of the query and radius to 7th decimal precision
+            # (3 miliarcsec) to avoid not catching get_gaia_sources() due to
+            # floating point error.
             ra_in = ra[_in]
             dec_in = dec[_in]
             # we use 50th percentile to get the centers and avoid 360-0 boundary
-            ra_q = np.round(np.percentile(ra_in, 50), decimals=6)
-            dec_q = np.round(np.percentile(dec_in, 50), decimals=6)
+            ra_q = np.round(np.percentile(ra_in, 50), decimals=7)
+            dec_q = np.round(np.percentile(dec_in, 50), decimals=7)
+            # +10/3600 to add a 10 arcsec to search radius, this is to get sources
+            # off sensor up to 10" distance from sensor border.
             rad_q = np.round(
-                np.hypot(ra_in - ra_q, dec_in - dec_q).max() + 10 / 3600, decimals=6
+                np.hypot(ra_in - ra_q, dec_in - dec_q).max() + 10 / 3600, decimals=7
             )
             # query gaia with ra, dec, rad, epoch
             result = get_gaia_sources(

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -121,14 +121,14 @@ def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
     dec_edges = np.histogram_bin_edges(dec, ngrid[1])
     sources = []
     # iterate over 2d bins
-    for ix in range(1, len(ra_edges)):
-        for jd in range(1, len(dec_edges)):
+    for idx in range(1, len(ra_edges)):
+        for jdx in range(1, len(dec_edges)):
             # check if image data fall in the bin
             _in = (
-                (ra_edges[ix - 1] <= ra)
-                & (ra <= ra_edges[ix])
-                & (dec_edges[jd - 1] <= dec)
-                & (dec <= dec_edges[jd])
+                (ra_edges[idx - 1] <= ra)
+                & (ra <= ra_edges[idx])
+                & (dec_edges[jdx - 1] <= dec)
+                & (dec <= dec_edges[jdx])
             )
             if not _in.any():
                 continue
@@ -138,13 +138,7 @@ def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
             ra_q = ra_in.mean()
             dec_q = dec_in.mean()
             rad_q = np.hypot(ra_in - ra_q, dec_in - dec_q).max() + 10 / 3600
-            # print(
-            #     "Will do small queries query with this (ra, dec, radius, epoch): ",
-            #     ra_q,
-            #     dec_q,
-            #     rad_q,
-            #     epoch,
-            # )
+            # query gaia with ra, dec, rad, epoch
             result = get_gaia_sources(
                 tuple([ra_q]),
                 tuple([dec_q]),

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -143,8 +143,8 @@ def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
             # we use 50th percentile to get the centers and avoid 360-0 boundary
             ra_q = np.round(np.percentile(ra_in, 50), decimals=7)
             dec_q = np.round(np.percentile(dec_in, 50), decimals=7)
-            # +10/3600 to add a 10 arcsec to search radius, this is to get sources
-            # off sensor up to 10" distance from sensor border.
+            # HARDCODED: +10/3600 to add a 10 arcsec to search radius, this is to get
+            # sources off sensor up to 10" distance from sensor border.
             rad_q = np.round(
                 np.hypot(ra_in - ra_q, dec_in - dec_q).max() + 10 / 3600, decimals=7
             )
@@ -160,7 +160,7 @@ def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
             sources.append(result)
     #  concat results and remove duplicated sources
     sources = pd.concat(sources, axis=0).drop_duplicates(subset=["designation"])
-    return sources
+    return sources.reset_index(drop=True)
 
 
 def _make_A_polar(phi, r, cut_r=6, rmin=1, rmax=18, n_r_knots=12, n_phi_knots=15):

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -90,9 +90,7 @@ def get_gaia_sources(ras, decs, rads, magnitude_limit=18, epoch=2020, dr=2):
     return gd.data.to_pandas()
 
 
-def do_tiled_query(
-    ra_grid, dec_grid, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3
-):
+def do_tiled_query(ra, dec, ngrid=(5, 5), magnitude_limit=18, epoch=2020, dr=3):
     """
     Find the centers and radius of the query when the sky area is large. This function
     divides the data into `ngrid` tiles and compute the ra, dec coordinates for each
@@ -100,10 +98,10 @@ def do_tiled_query(
 
     Parameters
     ----------
-    ra_grid : numpy.ndarray
-        Data array with values of Right Ascension.
-    dec_grid : numpy.ndarray
-        Data array with values of Declination.
+    ra : numpy.ndarray
+        Data array with values of Right Ascension. Arrays can be 2D image or flatten.
+    dec : numpy.ndarray
+        Data array with values of Declination. Arrays can be 2D image or flatten.
     ngrid : tuple
         Tuple with number of bins in each axis. Default is (5, 5).
     magnitude_limit : int
@@ -119,24 +117,24 @@ def do_tiled_query(
         Pandas DatFrame with number of result sources (rows) and Gaia columns
     """
     # find edges of the bins
-    ra_edges = np.histogram_bin_edges(ra_grid, ngrid[0])
-    dec_edges = np.histogram_bin_edges(dec_grid, ngrid[1])
+    ra_edges = np.histogram_bin_edges(ra, ngrid[0])
+    dec_edges = np.histogram_bin_edges(dec, ngrid[1])
     sources = []
     # iterate over 2d bins
     for ix in range(1, len(ra_edges)):
         for jd in range(1, len(dec_edges)):
             # check if image data fall in the bin
             _in = (
-                (ra_edges[ix - 1] <= ra_grid)
-                & (ra_grid <= ra_edges[ix])
-                & (dec_edges[jd - 1] <= dec_grid)
-                & (dec_grid <= dec_edges[jd])
+                (ra_edges[ix - 1] <= ra)
+                & (ra <= ra_edges[ix])
+                & (dec_edges[jd - 1] <= dec)
+                & (dec <= dec_edges[jd])
             )
             if not _in.any():
                 continue
             # get the center coord of the query and radius
-            ra_in = ra_grid[_in]
-            dec_in = dec_grid[_in]
+            ra_in = ra[_in]
+            dec_in = dec[_in]
             ra_q = ra_in.mean()
             dec_q = dec_in.mean()
             rad_q = np.hypot(ra_in - ra_q, dec_in - dec_q).max() + 10 / 3600

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -113,31 +113,6 @@ def test_do_tiled_query():
     # tiled query is always bigger that the other for TPF stacks.
     assert set(sources_org.designation).issubset(sources_tiled.designation)
 
-    # test for FFI like data ch=4 q=12
-    # create a ra, dec grid similar to the FFI data. Here for convinience, I use the
-    # wcs solution from the TPF to conv the pixel grid to radec.
-    row = np.arange(1024)
-    column = np.arange(1100)
-    row_grid, column_grid = np.meshgrid(row, column)
-    ra, dec = (
-        tpfs[0]
-        .wcs.wcs_pix2world(
-            np.vstack([column_grid.ravel(), row_grid.ravel()]).T,
-            0.0,
-        )
-        .T
-    )
-
-    ffi_sources = do_tiled_query(
-        ra,
-        dec,
-        ngrid=(5, 5),
-        magnitude_limit=18,
-        dr=3,
-        epoch=epoch,
-    )
-    assert ffi_sources.shape == (15822, 11)
-
     # Unit test for 360->0 deg boundary. we use a smaller sky patch now.
     row = np.arange(100)
     column = np.arange(100)
@@ -157,6 +132,6 @@ def test_do_tiled_query():
     boundary_sources = do_tiled_query(
         ra, dec, ngrid=(2, 2), magnitude_limit=16, epoch=epoch, dr=3
     )
-    assert boundary_sources.shape == (299, 11)
+    assert boundary_sources.shape == (85, 11)
     # check that no result objects are outside the boundary for ra
     assert not ((boundary_sources.ra < 359) & (boundary_sources.ra > 1)).all()

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import lightkurve as lk
 from astropy.utils.data import get_pkg_data_filename
+from astropy.time import Time
 
 from psfmachine import Machine, TPFMachine
 from psfmachine.tpf import (
@@ -14,6 +15,8 @@ from psfmachine.tpf import (
     _preprocess,
     _get_coord_and_query_gaia,
 )
+
+from psfmachine.utils import do_tiled_query
 
 tpfs = []
 for idx in range(10):
@@ -86,3 +89,73 @@ def test_parse_TPFs():
 def test_from_TPFs():
     c = TPFMachine.from_TPFs(tpfs)
     assert isinstance(c, Machine)
+
+
+def test_do_tiled_query():
+    # unit test for TPF stack
+    # test that the tiled query get the same results as the original psfmachine query
+    epoch = Time(tpfs[0].time[len(tpfs[0]) // 2], format="jd").jyear
+    sources_org = _get_coord_and_query_gaia(tpfs, magnitude_limit=18, dr=3)
+    _, ra, dec = _wcs_from_tpfs(tpfs)
+    sources_tiled = do_tiled_query(
+        ra,
+        dec,
+        ngrid=(2, 2),
+        magnitude_limit=18,
+        dr=3,
+        epoch=epoch,
+    )
+    assert isinstance(sources_tiled, pd.DataFrame)
+    assert set(["ra", "dec", "phot_g_mean_mag"]).issubset(sources_tiled.columns)
+    assert sources_tiled.shape == (83, 11)
+    # check that the tiled query contain all sources from the non-tiled query.
+    # tiled query is always bigger that the other.
+    assert set(sources_org.designation).issubset(sources_tiled.designation)
+
+    # test for FFI like data ch=4 q=12
+    # create a ra, dec grid similar to the FFI data. Here for convinience, I use the
+    # wcs solution from the TPF to conv the pixel grid to radec.
+    row = np.arange(1024)
+    column = np.arange(1100)
+    row_grid, column_grid = np.meshgrid(row, column)
+    ra, dec = (
+        tpfs[0]
+        .wcs.wcs_pix2world(
+            np.vstack([column_grid.ravel(), row_grid.ravel()]).T,
+            0.0,
+        )
+        .T
+    )
+
+    ffi_sources = do_tiled_query(
+        ra,
+        dec,
+        ngrid=(5, 5),
+        magnitude_limit=18,
+        dr=3,
+        epoch=epoch,
+    )
+    assert ffi_sources.shape == (15822, 11)
+
+    # Unit test for 360->0 deg boundary. we use a smaller sky patch now.
+    row = np.arange(100)
+    column = np.arange(100)
+    column_grid, row_grid = np.meshgrid(column, row)
+    # I subtract pix position to move the grid into the 360->0 ra boundary
+    column_grid -= 44200
+    ra, dec = (
+        tpfs[0]
+        .wcs.wcs_pix2world(
+            np.vstack([column_grid.ravel(), row_grid.ravel()]).T,
+            0.0,
+        )
+        .T
+    )
+    # check that ra values are in the boundary
+    assert not ((ra < 359) & (ra > 1)).all()
+    boundary_sources = do_tiled_query(
+        ra, dec, ngrid=(2, 2), magnitude_limit=18, epoch=epoch, dr=3
+    )
+    assert boundary_sources.shape == (299, 11)
+    # check that no result objects are outside the boundary for ra
+    assert not ((boundary_sources.ra < 359) & (boundary_sources.ra > 1)).all()

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -91,6 +91,7 @@ def test_from_TPFs():
     assert isinstance(c, Machine)
 
 
+@pytest.mark.remote_data
 def test_do_tiled_query():
     # unit test for TPF stack
     # test that the tiled query get the same results as the original psfmachine query
@@ -109,7 +110,7 @@ def test_do_tiled_query():
     assert set(["ra", "dec", "phot_g_mean_mag"]).issubset(sources_tiled.columns)
     assert sources_tiled.shape == (83, 11)
     # check that the tiled query contain all sources from the non-tiled query.
-    # tiled query is always bigger that the other.
+    # tiled query is always bigger that the other for TPF stacks.
     assert set(sources_org.designation).issubset(sources_tiled.designation)
 
     # test for FFI like data ch=4 q=12
@@ -154,7 +155,7 @@ def test_do_tiled_query():
     # check that ra values are in the boundary
     assert not ((ra < 359) & (ra > 1)).all()
     boundary_sources = do_tiled_query(
-        ra, dec, ngrid=(2, 2), magnitude_limit=18, epoch=epoch, dr=3
+        ra, dec, ngrid=(2, 2), magnitude_limit=16, epoch=epoch, dr=3
     )
     assert boundary_sources.shape == (299, 11)
     # check that no result objects are outside the boundary for ra


### PR DESCRIPTION
This function divides the sky area into (5, 5)  cells. Then it finds the `ra`, `dec`, and `radius` that cover each cell and queries Gaia with those parameters. Later, concatenate all results and returns all unique sources in the original sky area.