### PR TITLE
Optional focus mask

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -78,9 +78,9 @@ class TPFMachine(Machine):
         # )
         if time_mask is None and focus_mask is None:
             self.time_mask = np.ones(len(self.time), bool)
-        elif time_mask is None and not focus_mask is None:
+        elif time_mask is None and focus_mask is not None:
             self.time_mask = focus_mask
-        elif not time_mask is None and focus_mask is None:
+        elif time_mask is not None and focus_mask is None:
             self.time_mask = time_mask
         else:
             self.time_mask = time_mask & focus_mask

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -66,21 +66,24 @@ class TPFMachine(Machine):
         self.tpfs = tpfs
 
         # Cut out 1.5 days after every data gap
-        dt = np.hstack([10, np.diff(time)])
-        focus_mask = ~np.in1d(
-            np.arange(len(time)),
-            np.hstack(
-                [
-                    np.arange(t, t + int(1.5 / np.median(dt)))
-                    for t in np.where(dt > (np.median(dt) * 5))[0]
-                ]
-            ),
-        )
-        if time_mask is None:
+        # dt = np.hstack([10, np.diff(time)])
+        # focus_mask = ~np.in1d(
+        #     np.arange(len(time)),
+        #     np.hstack(
+        #         [
+        #             np.arange(t, t + int(1.5 / np.median(dt)))
+        #             for t in np.where(dt > (np.median(dt) * 5))[0]
+        #         ]
+        #     ),
+        # )
+        if time_mask is None and focus_mask is None:
+            self.time_mask = np.ones(len(self.time), bool)
+        elif time_mask is None and not focus_mask is None:
             self.time_mask = focus_mask
+        elif not time_mask is None and focus_mask is None:
+            self.time_mask = time_mask
         else:
             self.time_mask = time_mask & focus_mask
-
         self.pix2obs = pix2obs
         #        self.pos_corr1 = pos_corr1
         #        self.pos_corr2 = pos_corr2
@@ -420,6 +423,7 @@ class TPFMachine(Machine):
         magnitude_limit=18,
         dr=2,
         time_mask=None,
+        do_focus_mask=True,
         query_ra=None,
         query_dec=None,
         query_rad=None,
@@ -502,6 +506,7 @@ class TPFMachine(Machine):
 
         if time_mask is not None:
             time_mask = np.copy(time_mask)[qual_mask]
+        focus_mask = focus_mask if do_focus_mask else None
 
         # convert to RA Dec
         locs, ra, dec = _wcs_from_tpfs(tpfs)

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -65,17 +65,7 @@ class TPFMachine(Machine):
         )
         self.tpfs = tpfs
 
-        # Cut out 1.5 days after every data gap
-        # dt = np.hstack([10, np.diff(time)])
-        # focus_mask = ~np.in1d(
-        #     np.arange(len(time)),
-        #     np.hstack(
-        #         [
-        #             np.arange(t, t + int(1.5 / np.median(dt)))
-        #             for t in np.where(dt > (np.median(dt) * 5))[0]
-        #         ]
-        #     ),
-        # )
+        # combine focus mask and time mask if they exist
         if time_mask is None and focus_mask is None:
             self.time_mask = np.ones(len(self.time), bool)
         elif time_mask is None and focus_mask is not None:
@@ -631,6 +621,7 @@ def _parse_TPFs(tpfs, **kwargs):
             tpfs[0].quality, 1 | 2 | 4 | 8 | 32 | 16384 | 65536 | 1048576
         )
         qual_mask &= (np.abs(tpfs[0].pos_corr1) < 5) & (np.abs(tpfs[0].pos_corr2) < 5)
+        # Cut out 1.5 days after every data gap
         dt = np.hstack([10, np.diff(time)])
         focus_mask = ~np.in1d(
             np.arange(len(time)),

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -435,6 +435,25 @@ class TPFMachine(Machine):
         ----------
         tpfs: lightkurve TargetPixelFileCollection
             Collection of Target Pixel files
+        magnitude_limit : float
+            Limiting magnitude to query Gaia catalog.
+        dr : int
+            Gaia data release to be use, default is 2, options are DR2 and EDR3
+        time_mask : boolean array
+            Mask to be applied to discard cadences if needed.
+        apply_focus_mask : boolean
+            Mask or not cadances near observation gaps to remove focus change.
+        query_ra : numpy.array
+            Array of RA to query Gaia catalog. Default is `None` and will use the
+            coordinate centers of each TPF.
+        query_dec : numpy.array
+            Array of Dec to query Gaia catalog. Default is `None` and will use the
+            coordinate centers of each TPF.
+        query_rad : numpy.array
+            Array of radius to query Gaia catalog. Default is `None` and will use
+            the coordinate centers of each TPF.
+        **kwargs
+            Keyword arguments to be passed to `TPFMachine`.
 
         Returns
         -------

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -413,7 +413,7 @@ class TPFMachine(Machine):
         magnitude_limit=18,
         dr=2,
         time_mask=None,
-        do_focus_mask=True,
+        apply_focus_mask=True,
         query_ra=None,
         query_dec=None,
         query_rad=None,
@@ -497,7 +497,7 @@ class TPFMachine(Machine):
         if time_mask is not None:
             time_mask = np.copy(time_mask)[qual_mask]
         # use or not the focus mask
-        focus_mask = focus_mask if do_focus_mask else None
+        focus_mask = focus_mask if apply_focus_mask else None
 
         # convert to RA Dec
         locs, ra, dec = _wcs_from_tpfs(tpfs)

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -496,6 +496,7 @@ class TPFMachine(Machine):
 
         if time_mask is not None:
             time_mask = np.copy(time_mask)[qual_mask]
+        # use or not the focus mask
         focus_mask = focus_mask if do_focus_mask else None
 
         # convert to RA Dec

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -155,7 +155,7 @@ def test_do_tiled_query():
 @pytest.mark.remote_data
 def test_load_save_shape_model():
     # instantiate a machine object
-    machine = TPFMachine.from_TPFs(tpfs, do_focus_mask=False)
+    machine = TPFMachine.from_TPFs(tpfs, apply_focus_mask=False)
     # build a shape model from TPF data
     machine.build_shape_model(plot=False)
     # save object state
@@ -167,7 +167,7 @@ def test_load_save_shape_model():
     machine.save_shape_model(output=file_name)
 
     # instantiate a new machine object with same data but load shape model from disk
-    machine = TPFMachine.from_TPFs(tpfs, do_focus_mask=False)
+    machine = TPFMachine.from_TPFs(tpfs, apply_focus_mask=False)
     machine.load_shape_model(plot=False, input=file_name)
     new_state = machine.__dict__
 

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -154,14 +154,8 @@ def test_do_tiled_query():
 
 @pytest.mark.remote_data
 def test_load_save_shape_model():
-    # load sufficient TPFs to build a shape model
-    # the 10 TPFs in ./data/tpf_test* are not enough to fit a model, singular matrix
-    # error.
-    tpfs_k16 = lk.search_targetpixelfile(
-        "Kepler-16", mission="Kepler", quarter=12, radius=200, limit=10, cadence="long"
-    ).download_all(quality_bitmask=None)
     # instantiate a machine object
-    machine = TPFMachine.from_TPFs(tpfs_k16)
+    machine = TPFMachine.from_TPFs(tpfs, do_focus_mask=False)
     # build a shape model from TPF data
     machine.build_shape_model(plot=False)
     # save object state
@@ -173,7 +167,7 @@ def test_load_save_shape_model():
     machine.save_shape_model(output=file_name)
 
     # instantiate a new machine object with same data but load shape model from disk
-    machine = TPFMachine.from_TPFs(tpfs_k16)
+    machine = TPFMachine.from_TPFs(tpfs, do_focus_mask=False)
     machine.load_shape_model(plot=False, input=file_name)
     new_state = machine.__dict__
 
@@ -185,3 +179,5 @@ def test_load_save_shape_model():
     assert org_state["cut_r"] == new_state["cut_r"]
     assert (org_state["psf_w"] == new_state["psf_w"]).all()
     assert ((org_state["mean_model"] == new_state["mean_model"]).data).all()
+    # remove shape model from disk
+    os.remove(file_name)


### PR DESCRIPTION
Masking the time array for focus changes is optional now.  I include the decision of creating or not a focus mask within the `.from_TPFs()` method. This way `TPFMachine` can still accept a `focus_mask` argument (boolean array or None) to be combined with the `time_mask`.

Also remove duplicated code, `focus_mask` was been calculated inside `_parse_TPFs` and `TPFMachine.__init__'.

This PR closes #18 