### PR TITLE
small query fixed for "rectangular" TPFs

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -883,13 +883,13 @@ def _get_coord_and_query_gaia(
     if (ra is None) & (dec is None) & (rad is None):
         ras1, decs1 = np.asarray(
             [
-                tpf.wcs.all_pix2world([np.asarray(tpf.shape[1:]) + 4], 0)[0]
+                tpf.wcs.all_pix2world([np.asarray(tpf.shape[::-1][:2]) + 4], 0)[0]
                 for tpf in tpfs
             ]
         ).T
         ras, decs = np.asarray(
             [
-                tpf.wcs.all_pix2world([np.asarray(tpf.shape[1:]) // 2], 0)[0]
+                tpf.wcs.all_pix2world([np.asarray(tpf.shape[::-1][:2]) // 2], 0)[0]
                 for tpf in tpfs
             ]
         ).T


### PR DESCRIPTION
Fix issue #20.
The column, row were in the wrong order when converting into RA Dec coordinates in `_get_coord_and_query_gaia` to calculate the center and radius of the cone search.

Close #20.