### PR TITLE
[ISSUE #30]: computing radec from WCS of each TPF

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -828,26 +828,23 @@ def _wcs_from_tpfs(tpfs):
     dec: numpy.ndarray
         Array with declination values per pixel
     """
-    # calculate x,y grid of each pixel
-    locs = np.hstack(
-        [
-            np.mgrid[
-                tpf.column : tpf.column + tpf.shape[2],
-                tpf.row : tpf.row + tpf.shape[1],
-            ].reshape(2, np.product(tpf.shape[1:]))
-            for tpf in tpfs
-        ]
-    )
+    # calculate x,y grid of each pixel and RA, Dec
+    locs, ra, dec = [], [], []
+    for tpf in tpfs:
+        ij = np.mgrid[
+            tpf.column : tpf.column + tpf.shape[2],
+            tpf.row : tpf.row + tpf.shape[1],
+        ].reshape(2, np.product(tpf.shape[1:]))
+        ra_, dec_ = tpf.wcs.wcs_pix2world(
+            np.vstack([(ij[0] - tpf.column), (ij[1] - tpf.row)]).T, 0.0
+        ).T
+        locs.append(ij)
+        ra.extend(ra_)
+        dec.extend(dec_)
+    locs = np.hstack(locs)
+    ra = np.array(ra)
+    dec = np.array(dec)
 
-    # convert pixel coord to ra, dec using TPF's solution
-    ra, dec = (
-        tpfs[0]
-        .wcs.wcs_pix2world(
-            np.vstack([(locs[0] - tpfs[0].column), (locs[1] - tpfs[0].row)]).T,
-            0.0,
-        )
-        .T
-    )
     return locs, ra, dec
 
 


### PR DESCRIPTION
This PR fixes Issue #30. 
The pixel to world coordinate conversion is done by using the WCS solution of each TPF.

Figure to compare with the one posted in #30.
![image](https://user-images.githubusercontent.com/10449555/128914220-2eb7b39b-2bbf-4208-8a3b-962a9f2703a1.png)

closes #30 