### PR TITLE
[#37] Fix SAP bug when mean_model is zero for a source

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1327,6 +1327,8 @@ class Machine(object):
         )
         # create aperture mask
         self.aperture_mask = np.array(self.mean_model >= cut[::, None])
+        # make sure there are no all-pixel apertures due to `mean_model[i] = 0`
+        self.aperture_mask[self.aperture_mask.sum(axis=1) == self.npixels] = 0
         # compute flux metrics. Have to round to 10th decimal due to floating point
         self.FLFRCSAP = np.round(
             compute_FLFRCSAP(self.mean_model, self.aperture_mask), 10

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1328,7 +1328,7 @@ class Machine(object):
         # create aperture mask
         self.aperture_mask = np.array(self.mean_model >= cut[::, None])
         # make sure there are no all-pixel apertures due to `mean_model[i] = 0`
-        self.aperture_mask[self.aperture_mask.sum(axis=1) == self.npixels] = 0
+        self.aperture_mask[self.aperture_mask.sum(axis=1) == self.npixels] = False
         # compute flux metrics. Have to round to 10th decimal due to floating point
         self.FLFRCSAP = np.round(
             compute_FLFRCSAP(self.mean_model, self.aperture_mask), 10

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -147,6 +147,12 @@ class TPFMachine(Machine):
             self.load_shape_model(input=shape_model_file, plot=plot)
         else:
             self.build_shape_model(plot=plot)
+        # sap photometry is independent of the time model and fitting the PSF model.
+        # it only uses the shape mean_model
+        if sap:
+            self.compute_aperture_photometry(
+                aperture_size="optimal", target_complete=1, target_crowd=1
+            )
         self.build_time_model(plot=plot)
         self.fit_model(fit_va=fit_va)
         if iter_negative:
@@ -160,10 +166,6 @@ class TPFMachine(Machine):
                 idx += 1
                 if idx >= 3:
                     break
-        if sap:
-            self.compute_aperture_photometry(
-                aperture_size="optimal", target_complete=1, target_crowd=1
-            )
 
         self.lcs = []
         for idx, s in self.sources.iterrows():


### PR DESCRIPTION
This PR fixes #37.
I moved the sap photometry in `fit_lightcurve()` before fitting the PSF photometry and iteration over negatives because the SAP photometry is independent of the PSF one. it only uses the shape model. This avoids the problem of using a modified `mean_model`.
I also make sure that there are no "all-pixel" apertures when a source has `mean_model = 0`. In this case (usually for sources outside the TPF), an aperture can't be defined and is set to 0.