### PR TITLE
Gaia query

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -382,6 +382,14 @@ python-versions = ">=2.6, !=3.0.*"
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "diskcache"
+version = "5.3.0"
+description = "Disk Cache -- Disk and file backed persistent cache."
+category = "main"
+optional = false
+python-versions = ">=3"
+
+[[package]]
 name = "docstring-parser"
 version = "0.7.3"
 description = ""
@@ -1905,7 +1913,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "039ee5d6b61e92767596a66d53cf286f24245ac6aaecc7a2db8391f2d186a4ec"
+content-hash = "8e84fa3a3f8830e8d8b3a5e3367bd9565ee4ee722a93a66e97daf40d838e1a19"
 
 [metadata.files]
 aesara-theano-fallback = [
@@ -2143,6 +2151,10 @@ defusedxml = [
 dill = [
     {file = "dill-0.3.3-py2.py3-none-any.whl", hash = "sha256:78370261be6ea49037ace8c17e0b7dd06d0393af6513cc23f9b222d9367ce389"},
     {file = "dill-0.3.3.zip", hash = "sha256:efb7f6cb65dba7087c1e111bb5390291ba3616741f96840bfc75792a1a9b5ded"},
+]
+diskcache = [
+    {file = "diskcache-5.3.0-py3-none-any.whl", hash = "sha256:75138cacec6c1d7b8339cc78912dd218d955f0706123e447a322a7ea4c97f270"},
+    {file = "diskcache-5.3.0.tar.gz", hash = "sha256:3f1fa30b29fdff26cfddcb3ee7d61376903f82c769ea2907a2b82a5bfb8abbe2"},
 ]
 docstring-parser = [
     {file = "docstring_parser-0.7.3.tar.gz", hash = "sha256:cde5fbf8b846433dfbde1e0f96b7f909336a634d5df34a38cb75050c7346734a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ fitsio = "^1.1.3"
 jedi = "0.17.2"
 pandas = "^1.1"
 photutils = "^1.1.0"
+diskcache = "^5.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -2,14 +2,17 @@
 
 import numpy as np
 import pandas as pd
-import functools
+import diskcache
 
 from scipy import sparse
 from patsy import dmatrix
 import pyia
 
+# size_limit is 1GB
+cache = diskcache.Cache(directory="~/.psfmachine-cache")
 
-@functools.lru_cache()
+# @functools.lru_cache()
+@cache.memoize(expire=2.592e06)  # cache during 30 days
 def get_gaia_sources(ras, decs, rads, magnitude_limit=18, epoch=2020, dr=2):
     """
     Will find gaia sources using a TAP query, accounting for proper motions.
@@ -43,8 +46,8 @@ def get_gaia_sources(ras, decs, rads, magnitude_limit=18, epoch=2020, dr=2):
         rads = [rads]
     wheres = [
         f"""1=CONTAINS(
-                  POINT('ICRS',ra,dec),
-                  CIRCLE('ICRS',{ra},{dec},{rad}))"""
+                  POINT('ICRS',{ra},{dec}),
+                  CIRCLE('ICRS',ra,dec,{rad}))"""
         for ra, dec, rad in zip(ras, decs, rads)
     ]
 

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -11,8 +11,9 @@ import pyia
 # size_limit is 1GB
 cache = diskcache.Cache(directory="~/.psfmachine-cache")
 
-# @functools.lru_cache()
-@cache.memoize(expire=2.592e06)  # cache during 30 days
+
+# cache during 30 days
+@cache.memoize(expire=2.592e06)
 def get_gaia_sources(ras, decs, rads, magnitude_limit=18, epoch=2020, dr=2):
     """
     Will find gaia sources using a TAP query, accounting for proper motions.


### PR DESCRIPTION
This PR fixes issue #41 by changing the order of point/circle in the ADQL Gaia query following the recommendation here (green box):
https://www.cosmos.esa.int/web/gaia-users/archive/combine-with-other-data#CrossMatchUserTableFlag

Also adds disk cache instead of memory. Results are cached for 30 days with a size limit of 1GB.

Closes #41