### PR TITLE
use self.time_radius when building cartesian DM

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -932,7 +932,7 @@ class Machine(object):
             dx,
             dy,
             n_knots=self.n_time_knots,
-            radius=8,
+            radius=self.time_radius,
             spacing=self.cartesian_knot_spacing,
         )
         A2 = sparse.vstack([A_c] * time_binned.shape[0], format="csr")
@@ -1355,7 +1355,7 @@ class Machine(object):
                 dx,
                 dy,
                 n_knots=self.n_time_knots,
-                radius=8,
+                radius=self.time_radius,
                 spacing=self.cartesian_knot_spacing,
             )
             A_cp3 = sparse.hstack([A_cp, A_cp, A_cp, A_cp], format="csr")


### PR DESCRIPTION
This PR fixes #40 and makes sure that `self.time_radius` is always used when doing `_make_A_cartesian()`