### PR TITLE
:zap: tweaking PSFmachine to play with the K2 implementation

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -323,12 +323,13 @@ class Machine(object):
 
     def _get_source_mask(
         self,
-        upper_radius_limit=28.0,
+        upper_radius_limit=36.0,
         lower_radius_limit=4.5,
         upper_flux_limit=2e5,
-        lower_flux_limit=100,
+        lower_flux_limit=40,
         correct_centroid_offset=True,
         plot=False,
+        frame_index="mean",
     ):
         """Find the pixel mask that identifies pixels with contributions from ANY NUMBER of Sources
 
@@ -477,6 +478,7 @@ class Machine(object):
         source_radius_limit = np.polyval(
             np.polyfit(test_f[ok], l[ok], 1), np.log10(self.source_flux_estimates)
         )
+
         source_radius_limit[
             source_radius_limit > upper_radius_limit
         ] = upper_radius_limit
@@ -501,7 +503,7 @@ class Machine(object):
         # Now we can update the r and phi estimates, allowing for a slight centroid
         # calculate image centroids and correct dra,ddec for offset.
         if correct_centroid_offset:
-            self._get_centroids()
+            self._get_centroids(frame_index=frame_index)
             # print(self.ra_centroid_avg.to("arcsec"), self.dec_centroid_avg.to("arcsec"))
             # re-estimate dra, ddec with centroid shifts, check if sparse case applies.
             # Hardcoded: sparse implementation is efficient when nsourxes * npixels < 1e7
@@ -510,15 +512,23 @@ class Machine(object):
             if self.nsources * self.npixels < 1e7:
                 self._create_delta_arrays(
                     centroid_offset=[
-                        self.ra_centroid_avg.value,
-                        self.dec_centroid_avg.value,
+                        self.ra_centroid_avg.value
+                        if frame_index == "mean"
+                        else self.ra_centroid[frame_index].value,
+                        self.dec_centroid_avg.value
+                        if frame_index == "mean"
+                        else self.dec_centroid[frame_index].value,
                     ]
                 )
             else:
                 self._create_delta_sparse_arrays(
                     centroid_offset=[
-                        self.ra_centroid_avg.value,
-                        self.dec_centroid_avg.value,
+                        self.ra_centroid_avg.value
+                        if frame_index == "mean"
+                        else self.ra_centroid[frame_index].value,
+                        self.dec_centroid_avg.value
+                        if frame_index == "mean"
+                        else self.dec_centroid[frame_index].value,
                     ]
                 )
             # if centroid offset id larger than 1" then we need to recalculate the
@@ -590,7 +600,7 @@ class Machine(object):
         return
 
     # CH: We're not currently using this, but it might prove useful later so I will leave for now
-    def _get_centroids(self):
+    def _get_centroids(self, frame_index="mean"):
         """
         Find the ra and dec centroid of the image, at each time.
         """
@@ -599,22 +609,30 @@ class Machine(object):
         self.dec_centroid = np.zeros(self.nt)
         dra_m = self.uncontaminated_source_mask.multiply(self.dra).data
         ddec_m = self.uncontaminated_source_mask.multiply(self.ddec).data
-        for t in range(self.nt):
-            wgts = self.uncontaminated_source_mask.multiply(
-                np.sqrt(np.abs(self.flux[t]))
-            ).data
+        if frame_index == "mean":
+            ts = np.where(self.time_mask)[0]
+        else:
+            ts = np.atleast_1d(frame_index)
+        for t in ts:
+            wgts = (
+                self.uncontaminated_source_mask.multiply(self.flux[t])
+                .multiply(1 / self.source_flux_estimates[:, None])
+                .data
+                ** 2
+            )
             # mask out non finite values and background pixels
             k = (np.isfinite(wgts)) & (
-                self.uncontaminated_source_mask.multiply(self.flux[t]).data > 100
+                self.uncontaminated_source_mask.multiply(self.flux[t]).data > 10
             )
             self.ra_centroid[t] = np.average(dra_m[k], weights=wgts[k])
             self.dec_centroid[t] = np.average(ddec_m[k], weights=wgts[k])
+
         del dra_m, ddec_m
         self.ra_centroid *= u.deg
         self.dec_centroid *= u.deg
-        self.ra_centroid_avg = self.ra_centroid.mean()
-        self.dec_centroid_avg = self.dec_centroid.mean()
-
+        if frame_index == "mean":
+            self.ra_centroid_avg = np.nanmean(self.ra_centroid)
+            self.dec_centroid_avg = np.nanmean(self.dec_centroid)
         return
 
     def _time_bin(self, npoints=200, downsample=False):
@@ -691,7 +709,11 @@ class Machine(object):
         if not downsample:
             # time averaged between breaks
             tm = np.vstack(
-                [t1.mean(axis=0) for t1 in np.array_split(self.time, breaks)]
+                [
+                    t1.mean(axis=0)
+                    for t1 in np.array_split(self.time, breaks)
+                    if len(t1) != 0
+                ]
             ).ravel()
             # whiten the time array
             ta = (self.time - tm.mean()) / (tm.max() - tm.mean())
@@ -699,6 +721,7 @@ class Machine(object):
             ms = [
                 np.in1d(np.arange(self.nt), i)
                 for i in np.array_split(np.arange(self.nt), breaks)
+                if len(i) != 0
             ]
             # Average Pixel flux values
             fm = np.asarray(
@@ -726,7 +749,11 @@ class Machine(object):
         else:
             dwns_idx = (
                 np.vstack(
-                    [np.median(t1) for t1 in np.array_split(np.arange(self.nt), breaks)]
+                    [
+                        np.median(t1)
+                        for t1 in np.array_split(np.arange(self.nt), breaks)
+                        if len(t1) != 0
+                    ]
                 )
                 .ravel()
                 .astype(int)
@@ -789,10 +816,18 @@ class Machine(object):
             # do poscorr binning
             if not downsample:
                 pc1_bin = np.vstack(
-                    [np.median(t1, axis=0) for t1 in np.array_split(pc1_smooth, breaks)]
+                    [
+                        np.median(t1, axis=0)
+                        for t1 in np.array_split(pc1_smooth, breaks)
+                        if len(t1) != 0
+                    ]
                 ).ravel()[:, None] * np.ones(fm.shape)
                 pc2_bin = np.vstack(
-                    [np.median(t1, axis=0) for t1 in np.array_split(pc2_smooth, breaks)]
+                    [
+                        np.median(t1, axis=0)
+                        for t1 in np.array_split(pc2_smooth, breaks)
+                        if len(t1) != 0
+                    ]
                 ).ravel()[:, None] * np.ones(fm.shape)
             else:
                 pc1_bin = pc1_smooth[dwns_idx][:, None] * np.ones(fm.shape)
@@ -1225,7 +1260,7 @@ class Machine(object):
                 self.mean_model.T.dot(self.source_flux_estimates)
             ).tocsr()
             > flux_cut_off
-        )
+        ).multiply(self.mean_model > 0.005)
 
         # Recreate uncontaminated mask
         self._get_uncontaminated_pixel_mask()

--- a/src/psfmachine/superstamp.py
+++ b/src/psfmachine/superstamp.py
@@ -106,6 +106,7 @@ class SSMachine(FFIMachine):
         org_sm = self.source_mask
         org_usm = self.uncontaminated_source_mask
         for tdx in tqdm(range(self.nt), desc="Building shape model per frame"):
+            self._get_source_mask(frame_index=tdx)
             fig = self.build_shape_model(frame_index=tdx, plot=plot, **kwargs)
             self.mean_model_frame.append(self.mean_model)
             if plot:
@@ -352,12 +353,11 @@ class SSMachine(FFIMachine):
         # fit shape model at each cadence
         self.build_frame_shape_model()
         self.fit_frame_model()
-
         self.lcs = []
         for idx, s in self.sources.iterrows():
             meta = {
                 "ORIGIN": "PSFMACHINE",
-                "APERTURE": "PSF + SAP" if sap else "PSF",
+                "APERTURE": "PSF + SAP" if hasattr(self, "sap_flux") else "PSF",
                 "LABEL": s.designation,
                 "MISSION": self.meta["MISSION"],
                 "RA": s.ra,

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -206,10 +206,11 @@ def _make_A_cartesian(x, y, n_knots=10, radius=3.0, spacing="sqrt"):
         np.asarray(
             dmatrix(
                 "bs(x, knots=knots, degree=3, include_intercept=True)",
-                {"x": list(x), "knots": x_knots},
+                {"x": np.hstack([x_knots[0], x, x_knots[-1]]), "knots": x_knots},
             )
         )
-    )
+    )[1:-1]
+
     if spacing == "sqrt":
         y_knots = np.linspace(-np.sqrt(radius), np.sqrt(radius), n_knots)
         y_knots = np.sign(y_knots) * y_knots ** 2
@@ -219,10 +220,10 @@ def _make_A_cartesian(x, y, n_knots=10, radius=3.0, spacing="sqrt"):
         np.asarray(
             dmatrix(
                 "bs(x, knots=knots, degree=3, include_intercept=True)",
-                {"x": list(y), "knots": y_knots},
+                {"x": np.hstack([y_knots[0], y, y_knots[-1]]), "knots": y_knots},
             )
         )
-    )
+    )[1:-1]
     X = sparse.hstack(
         [x_spline.multiply(y_spline[:, idx]) for idx in range(y_spline.shape[1])],
         format="csr",


### PR DESCRIPTION
I'm taking a look at PSFmachine for ruprecht, and making a few tweaks. I'm opening this issue to discuss these tweaks.

Here's a rough log of changes:

1. Changed the `_update_source_mask...` function so that it more aggressively clips out the faint edges of the PSF
2. Messed a little with some of the sane defaults for the masking function
3. Added a slightly more robust error catch for the "breaks" in time binning,
4. Get centroid takes a frame index so it will only calculate the centroid of the current frame unless "mean" is passed...(this might not be advisable)
5. `_get_source_mask` now puts the centroid to the centroid of the `frame_index`, making sure that per cadence PSFs are always centered at zero.
6. `build_frame_shape_model` recalculates the source mask at every step

The last point makes sure that the PSF is always centered at 0,0 when we fit it. This is important, as our model is only valid if the PSF it's modeling is centered.


However, the way it is currently set up, this becomes quite intractable for large datasets...!