### PR TITLE
Optional data binning in shape model

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1077,12 +1077,6 @@ class Machine(object):
         # not contaminated etc
         self._get_uncontaminated_pixel_mask()
 
-        # remove pixels belonging to sources fainter than 1e4 (gaia flux)
-        # self.uncontaminated_source_mask = self.uncontaminated_source_mask.multiply(
-        #     (self.source_flux_estimates > 1e4)[:, None]
-        # )
-        # self.uncontaminated_source_mask.eliminate_zeros()
-
         # for iter in range(niters):
         flux_estimates = self.source_flux_estimates[:, None]
 
@@ -1119,10 +1113,9 @@ class Machine(object):
         # take value from Quantity is not necessary
         phi_b = self.uncontaminated_source_mask.multiply(self.phi).data
         r_b = self.uncontaminated_source_mask.multiply(self.r).data
-        print(r_b.shape)
 
         if bin_data:
-            nbins = 25 if mean_f.shape[0] <= 5e3 else 100
+            nbins = 30 if mean_f.shape[0] <= 5e3 else 100
             phi_b, r_b, mean_f = threshold_binning(
                 phi_b,
                 r_b,
@@ -1130,7 +1123,6 @@ class Machine(object):
                 bins=nbins,
                 abs_thresh=5,
             )
-        print(r_b.shape)
 
         # build a design matrix A with b-splines basis in radius and angle axis.
         A = _make_A_polar(
@@ -1316,7 +1308,7 @@ class Machine(object):
         dy = dy.data * u.deg.to(u.arcsecond)
 
         if bin_data:
-            nbins = 25 if mean_f.shape[0] <= 5e3 else 100
+            nbins = 30 if mean_f.shape[0] <= 5e3 else 100
             dx, dy, mean_f = threshold_binning(dx, dy, mean_f, bins=nbins, abs_thresh=5)
 
         fig, ax = plt.subplots(3, 2, figsize=(9, 10.5), constrained_layout=True)

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1115,8 +1115,8 @@ class Machine(object):
         r_b = self.uncontaminated_source_mask.multiply(self.r).data
 
         if bin_data:
-            nbins = 30 if mean_f.shape[0] <= 5e3 else 100
-            phi_b, r_b, mean_f, mean_f_err = threshold_bin(
+            nbins = 30 if mean_f.shape[0] <= 5e3 else 90
+            _, phi_b, r_b, mean_f, mean_f_err = threshold_bin(
                 phi_b,
                 r_b,
                 mean_f,
@@ -1309,8 +1309,10 @@ class Machine(object):
         dy = dy.data * u.deg.to(u.arcsecond)
 
         if bin_data:
-            nbins = 30 if mean_f.shape[0] <= 5e3 else 100
-            dx, dy, mean_f, _ = threshold_bin(dx, dy, mean_f, bins=nbins, abs_thresh=5)
+            nbins = 30 if mean_f.shape[0] <= 5e3 else 90
+            _, dx, dy, mean_f, _ = threshold_bin(
+                dx, dy, mean_f, bins=nbins, abs_thresh=5
+            )
 
         fig, ax = plt.subplots(3, 2, figsize=(9, 10.5), constrained_layout=True)
         im = ax[0, 0].scatter(

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -16,6 +16,7 @@ from .utils import (
     solve_linear_model,
     sparse_lessthan,
     _combine_A,
+    threshold_binning,
 )
 from .aperture import optimize_aperture, compute_FLFRCSAP, compute_CROWDSAP
 
@@ -1048,7 +1049,7 @@ class Machine(object):
         return fig
 
     def build_shape_model(
-        self, plot=False, flux_cut_off=1, frame_index="mean", **kwargs
+        self, plot=False, flux_cut_off=1, frame_index="mean", bin_data=False, **kwargs
     ):
         """
         Builds a sparse model matrix of shape nsources x npixels to be used when
@@ -1113,6 +1114,11 @@ class Machine(object):
         phi_b = self.uncontaminated_source_mask.multiply(self.phi).data
         r_b = self.uncontaminated_source_mask.multiply(self.r).data
 
+        if bin_data:
+            phi_b, r_b, mean_f = threshold_binning(
+                phi_b, r_b, mean_f, bins=100, abs_thresh=3
+            )
+
         # build a design matrix A with b-splines basis in radius and angle axis.
         A = _make_A_polar(
             phi_b.ravel(),
@@ -1162,7 +1168,7 @@ class Machine(object):
         )
 
         if plot:
-            return self.plot_shape_model(frame_index=frame_index)
+            return self.plot_shape_model(frame_index=frame_index, bin_data=bin_data)
         return
 
     def _update_source_mask_remove_bkg_pixels(self, flux_cut_off=1, frame_index="mean"):
@@ -1256,7 +1262,7 @@ class Machine(object):
         mean_model.eliminate_zeros()
         self.mean_model = mean_model
 
-    def plot_shape_model(self, radius=20, frame_index="mean"):
+    def plot_shape_model(self, radius=20, frame_index="mean", bin_data=False):
         """
         Diagnostic plot of shape model.
 
@@ -1295,6 +1301,9 @@ class Machine(object):
         )
         dx = dx.data * u.deg.to(u.arcsecond)
         dy = dy.data * u.deg.to(u.arcsecond)
+
+        if bin_data:
+            dx, dy, mean_f = threshold_binning(dx, dy, mean_f, bins=100, abs_thresh=3)
 
         fig, ax = plt.subplots(3, 2, figsize=(9, 10.5), constrained_layout=True)
         im = ax[0, 0].scatter(

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1115,7 +1115,13 @@ class Machine(object):
         r_b = self.uncontaminated_source_mask.multiply(self.r).data
 
         if bin_data:
-            nbins = 30 if mean_f.shape[0] <= 5e3 else 90
+            # number of bins is hardcoded to work with FFI or TPFs accordingly
+            # I found 30 wirks good with TPF stacks (<10000 pixels),
+            # 90 with FFIs (tipically >50k pixels), and 60 in between.
+            # this could be improved later if necessary
+            nbins = (
+                30 if mean_f.shape[0] <= 1e4 else (60 if mean_f.shape[0] <= 5e4 else 90)
+            )
             _, phi_b, r_b, mean_f, mean_f_err = threshold_bin(
                 phi_b,
                 r_b,

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -16,7 +16,7 @@ from .utils import (
     solve_linear_model,
     sparse_lessthan,
     _combine_A,
-    threshold_binning,
+    threshold_bin,
 )
 from .aperture import optimize_aperture, compute_FLFRCSAP, compute_CROWDSAP
 
@@ -1116,10 +1116,11 @@ class Machine(object):
 
         if bin_data:
             nbins = 30 if mean_f.shape[0] <= 5e3 else 100
-            phi_b, r_b, mean_f = threshold_binning(
+            phi_b, r_b, mean_f, mean_f_err = threshold_bin(
                 phi_b,
                 r_b,
                 mean_f,
+                z_err=mean_f_err,
                 bins=nbins,
                 abs_thresh=5,
             )
@@ -1309,7 +1310,7 @@ class Machine(object):
 
         if bin_data:
             nbins = 30 if mean_f.shape[0] <= 5e3 else 100
-            dx, dy, mean_f = threshold_binning(dx, dy, mean_f, bins=nbins, abs_thresh=5)
+            dx, dy, mean_f, _ = threshold_bin(dx, dy, mean_f, bins=nbins, abs_thresh=5)
 
         fig, ax = plt.subplots(3, 2, figsize=(9, 10.5), constrained_layout=True)
         im = ax[0, 0].scatter(

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -463,8 +463,7 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
     z : numpy.ndarray
         Data array with the number values for each (X, Y) point.
     z_err : numpy.ndarray
-        Array with errors values for z. Error propagation and agregation is done
-        assuming z values are in Flux space, not log.
+        Array with errors values for z.
     abs_thresh : int
         Absolute threshold is the number of bib members to compute the statistic,
         otherwise data will be preserved.
@@ -522,7 +521,7 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
                 bin_map.append(len(idx))
                 if isinstance(z_err, np.ndarray):
                     # agregate errors if provided and sccale by bin member number
-                    new_z_err.append(np.sqrt(np.nansum(z[idx] ** 2)) / len(idx))
+                    new_z_err.append(np.sqrt(np.nansum(z_err[idx] ** 2)) / len(idx))
 
     # adding non-binned datapoints
     new_x.append(x[~bin_mask])
@@ -534,7 +533,7 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
         # keep original z errors if provided
         new_z_err.append(z_err[~bin_mask])
     else:
-        new_z_err = 1 / bin_map
+        new_z_err = 1 / np.hstack(bin_map)
 
     return (
         np.hstack(bin_map),

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -486,7 +486,8 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
     new_z : numpy.ndarray
         Binned Z data.
     new_z_err : numpy.ndarray
-        BInned Z_err data if errors were provided.
+        BInned Z_err data if errors were provided. If no, inverse of the number of
+        bin members are returned as weights.
     """
     if bins < 2 or bins > len(x):
         raise ValueError(
@@ -532,17 +533,13 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
     if isinstance(z_err, np.ndarray):
         # keep original z errors if provided
         new_z_err.append(z_err[~bin_mask])
-        return (
-            np.hstack(bin_map),
-            np.hstack(new_x),
-            np.hstack(new_y),
-            np.hstack(new_z),
-            np.hstack(new_z_err),
-        )
     else:
-        return (
-            np.hstack(bin_map),
-            np.hstack(new_x),
-            np.hstack(new_y),
-            np.hstack(new_z),
-        )
+        new_z_err = 1 / bin_map
+
+    return (
+        np.hstack(bin_map),
+        np.hstack(new_x),
+        np.hstack(new_y),
+        np.hstack(new_z),
+        np.hstack(new_z_err),
+    )

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -445,7 +445,7 @@ def _combine_A(A, poscorr=None, time=None):
         return A2
 
 
-def threshold_binning(x, y, z, abs_thresh=10, bins=15, statistic=np.nanmedian):
+def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanmedian):
     """
     Function to bin 2D data and compute array statistic based on density.
     This function inputs 2D coordinates, e.g. `X` and `Y` locations, and a number value
@@ -456,12 +456,15 @@ def threshold_binning(x, y, z, abs_thresh=10, bins=15, statistic=np.nanmedian):
 
     Parameters
     ----------
-    x : numpy.array
+    x : numpy.ndarray
         Data array with spatial coordinate 1.
-    y : numpy.array
+    y : numpy.ndarray
         Data array with spatial coordinate 2.
-    z : numpy.array
+    z : numpy.ndarray
         Data array with the number values for each (X, Y) point.
+    z_err : numpy.ndarray
+        Array with errors values for z. Error propagation and agregation is done
+        assuming z values are in Flux space, not log.
     abs_thresh : int
         Absolute threshold is the number of bib members to compute the statistic,
         otherwise data will be preserved.
@@ -474,20 +477,32 @@ def threshold_binning(x, y, z, abs_thresh=10, bins=15, statistic=np.nanmedian):
 
     Returns
     -------
-    new_x : numpy.array
+    bin_map : numpy.ndarray
+        2D histogram values
+    new_x : numpy.ndarray
         Binned X data.
-    new_y : numpy.array
+    new_y : numpy.ndarray
         Binned Y data.
-    new_f : numpy.array
+    new_z : numpy.ndarray
         Binned Z data.
+    new_z_err : numpy.ndarray
+        BInned Z_err data if errors were provided.
     """
-
+    if bins < 2 or bins > x.shape[0]:
+        raise ValueError(
+            "Number of bins is negative or higher than number of points in (x, y, z)"
+        )
+    if abs_thresh < 1:
+        raise ValueError(
+            "Absolute threshold is 0 or negative, please input a value > 1"
+        )
     if isinstance(bins, int):
         bins = [bins, bins]
-    xedges = np.linspace(x.min(), x.max(), num=bins[0] + 1)
-    yedges = np.linspace(y.min(), y.max(), num=bins[1] + 1)
+
+    xedges = np.linspace(np.nanmin(x), np.nanmax(x), num=bins[0] + 1)
+    yedges = np.linspace(np.nanmin(y), np.nanmax(y), num=bins[1] + 1)
     bin_mask = np.zeros_like(z, dtype=bool)
-    new_x, new_y, new_z = [], [], []
+    new_x, new_y, new_z, new_z_err, bin_map = [], [], [], [], []
 
     for j in range(1, len(xedges)):
         for k in range(1, len(yedges)):
@@ -499,11 +514,35 @@ def threshold_binning(x, y, z, abs_thresh=10, bins=15, statistic=np.nanmedian):
             )[0]
             if len(idx) >= abs_thresh:
                 bin_mask[idx] = True
+                # we agregate bin memebers
                 new_x.append((xedges[j - 1] + xedges[j]) / 2)
                 new_y.append((yedges[k - 1] + yedges[k]) / 2)
                 new_z.append(statistic(z[idx]))
+                bin_map.append(len(idx))
+                if isinstance(z_err, np.ndarray):
+                    # agregate errors if provided and sccale by bin member number
+                    new_z_err.append(np.sqrt(np.nansum(z[idx] ** 2)) / len(idx))
+
+    # adding non-binned datapoints
     new_x.append(x[~bin_mask])
     new_y.append(y[~bin_mask])
     new_z.append(z[~bin_mask])
+    bin_map.append(np.ones_like(z)[~bin_mask])
 
-    return (np.hstack(new_x), np.hstack(new_y), np.hstack(new_z))
+    if isinstance(z_err, np.ndarray):
+        # keep original z errors if provided
+        new_z_err.append(z_err[~bin_mask])
+        return (
+            np.hstack(bin_map),
+            np.hstack(new_x),
+            np.hstack(new_y),
+            np.hstack(new_z),
+            np.hstack(new_z_err),
+        )
+    else:
+        return (
+            np.hstack(bin_map),
+            np.hstack(new_x),
+            np.hstack(new_y),
+            np.hstack(new_z),
+        )

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -488,13 +488,13 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
     new_z_err : numpy.ndarray
         BInned Z_err data if errors were provided.
     """
-    if bins < 2 or bins > x.shape[0]:
+    if bins < 2 or bins > len(x):
         raise ValueError(
             "Number of bins is negative or higher than number of points in (x, y, z)"
         )
     if abs_thresh < 1:
         raise ValueError(
-            "Absolute threshold is 0 or negative, please input a value > 1"
+            "Absolute threshold is 0 or negative, please input a value > 0"
         )
     if isinstance(bins, int):
         bins = [bins, bins]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import numpy as np
+from psfmachine.utils import threshold_bin
+
+
+def test_threshold_bin():
+
+    # Pass a bunch of nans
+    x, y, z = (
+        np.random.normal(size=1000),
+        np.random.normal(size=1000),
+        np.ones(1000) * np.nan,
+    )
+    hist, xbin, ybin, zbin = threshold_bin(x, y, z)
+    assert xbin.shape[0] <= x.shape[0]
+    assert np.isnan(zbin).all()
+    assert hist.min() >= 1.0
+
+    # Pass something that should actually pass
+    x = np.random.normal(0, 1, 5000)
+    y = np.random.normal(0, 1, 5000)
+    z = np.power(10, -(((x ** 2 + y ** 2) / 0.5) ** 0.5) / 2)
+    hist, xbin, ybin, zbin = threshold_bin(x, y, z, abs_thresh=5, bins=50)
+    # check that some points are binned, some points are not
+    assert xbin.shape[0] <= x.shape[0]
+    assert np.isin(zbin, z).sum() > 0
+    assert hist.min() >= 1.0
+
+    # add random nan values to Z
+    z[np.random.randint(0, 5000, 50)] = np.nan
+    hist2, xbin2, ybin2, zbin2 = threshold_bin(x, y, z, abs_thresh=5, bins=50)
+    # check that some points are binned, some points are not
+    assert xbin2.shape[0] <= x.shape[0]
+    assert np.isin(zbin2, z).sum() > 0
+    assert hist2.min() >= 1.0
+    # We should get the same outut for (hist, xbin, ybin) and same shape for zbin
+    assert (hist == hist2).all()
+    assert (xbin == xbin2).all()
+    assert (ybin == ybin2).all()
+    assert zbin.shape == hist2.shape

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ def test_threshold_bin():
         np.random.normal(size=1000),
         np.ones(1000) * np.nan,
     )
-    hist, xbin, ybin, zbin = threshold_bin(x, y, z)
+    hist, xbin, ybin, zbin, zwbin = threshold_bin(x, y, z)
     assert xbin.shape[0] <= x.shape[0]
     assert np.isnan(zbin).all()
     assert hist.min() >= 1.0
@@ -19,15 +19,19 @@ def test_threshold_bin():
     x = np.random.normal(0, 1, 5000)
     y = np.random.normal(0, 1, 5000)
     z = np.power(10, -(((x ** 2 + y ** 2) / 0.5) ** 0.5) / 2)
-    hist, xbin, ybin, zbin = threshold_bin(x, y, z, abs_thresh=5, bins=50)
+    hist, xbin, ybin, zbin, zwbin = threshold_bin(x, y, z, abs_thresh=5, bins=50)
     # check that some points are binned, some points are not
+    assert hist.shape == xbin.shape
+    assert hist.shape == ybin.shape
+    assert hist.shape == zbin.shape
+    assert hist.shape == zwbin.shape
     assert xbin.shape[0] <= x.shape[0]
     assert np.isin(zbin, z).sum() > 0
     assert hist.min() >= 1.0
 
     # add random nan values to Z
     z[np.random.randint(0, 5000, 50)] = np.nan
-    hist2, xbin2, ybin2, zbin2 = threshold_bin(x, y, z, abs_thresh=5, bins=50)
+    hist2, xbin2, ybin2, zbin2, zwbin = threshold_bin(x, y, z, abs_thresh=5, bins=50)
     # check that some points are binned, some points are not
     assert xbin2.shape[0] <= x.shape[0]
     assert np.isin(zbin2, z).sum() > 0


### PR DESCRIPTION
This adds the option of binning the `(dx, dy)` data, taking the median value of `mean_f` if a certain number of bin members are found, or preserving data otherwise. 
This allows fitting a "cleaner" model where the PSF is bright.

Here a generic example:
<img width="883" alt="Screen Shot 2022-02-09 at 13 12 14" src="https://user-images.githubusercontent.com/10449555/153482619-eba2b075-f451-4098-a7e6-0c4ab10e1a77.png">

and a `build_shape_model(bin_data=True)` example
![image](https://user-images.githubusercontent.com/10449555/153482594-759318a1-d779-4013-bceb-13ba1b3f82f7.png)

The new `utils.threshold_binning()` function is early flexible. It allows to change the number of bins, the absolute threshold (number of bin members when taking the median), and use different statistics (e.g. median, mean). 
It takes ~200 ms for a set of 10k data points, that's the typical number of pixels in a ~200 TPF stack. For an FFI with ~100k pixels, it takes ~1.4 s. 
