### PR TITLE
Fitting time model for intra-quarter segments 

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -732,19 +732,18 @@ class Machine(object):
             )
         else:
             # use breaks as downsample points
-            dwns_idx = breaks
-            tm = self.time[dwns_idx]
+            tm = self.time[breaks]
             ta = (self.time - tm.mean()) / (tm.max() - tm.mean())
             fm = np.asarray(
                 [
                     self.uncontaminated_source_mask.multiply(self.flux[idx]).data
-                    for idx in dwns_idx
+                    for idx in breaks
                 ]
             )
             fem = np.asarray(
                 [
                     self.uncontaminated_source_mask.multiply(self.flux_err[idx]).data
-                    for idx in dwns_idx
+                    for idx in breaks
                 ]
             )
 
@@ -803,8 +802,8 @@ class Machine(object):
                     [np.median(t1, axis=0) for t1 in np.array_split(pc2_smooth, breaks)]
                 ).ravel()[:, None] * np.ones(fm.shape)
             else:
-                pc1_bin = pc1_smooth[dwns_idx][:, None] * np.ones(fm.shape)
-                pc2_bin = pc2_smooth[dwns_idx][:, None] * np.ones(fm.shape)
+                pc1_bin = pc1_smooth[breaks][:, None] * np.ones(fm.shape)
+                pc2_bin = pc2_smooth[breaks][:, None] * np.ones(fm.shape)
 
             return (
                 ta,
@@ -933,12 +932,12 @@ class Machine(object):
             else:
                 A3 = _combine_A(A2, time=time_binned[seg_mask])
 
-            # No saturated pixels
+            # No saturated pixels, 1e5 is a hardcoded value for Kepler.
             k = (
-                (flux_binned_raw < 1.4e5).all(axis=0)[None, :]
+                (flux_binned_raw < 1e5).all(axis=0)[None, :]
                 * np.ones(flux_binned_raw[seg_mask].shape, bool)
             ).ravel()
-            # No faint pixels
+            # No faint pixels, 100 is a hardcoded value for Kepler.
             k &= (
                 (flux_binned_raw[seg_mask] > 100).all(axis=0)[None, :]
                 * np.ones(flux_binned_raw[seg_mask].shape, bool)

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -732,6 +732,10 @@ class Machine(object):
             )
         else:
             # use breaks as downsample points
+            # when working with short light curves, need to make sure the last break
+            # point isn't the lenght of the time.
+            if breaks[-1] == self.nt:
+                breaks[-1] -= 1
             tm = self.time[breaks]
             ta = (self.time - tm.mean()) / (tm.max() - tm.mean())
             fm = np.asarray(

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -906,7 +906,7 @@ class Machine(object):
         if isinstance(split_time_model, (np.ndarray, list)):
             # we make sure first and last index are included and sorted
             splits = np.unique(np.append(split_time_model, [0, len(self.time)]))
-        else:
+        elif isinstance(split_time_model, bool):
             # we find the splits in data
             if split_time_model:
                 splits = get_breaks(self.time)

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -542,3 +542,21 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
         np.hstack(new_z),
         np.hstack(new_z_err),
     )
+
+
+def get_breaks(time):
+    """
+    Finds discontinuity in the time array and return the break indexes.
+
+    Parameters
+    ----------
+    time : numpy.ndarray
+        Array with time values
+
+    Returns
+    -------
+    splits : numpy.ndarray
+        An array of indexes with the break positions
+    """
+    dts = np.diff(time)
+    return np.hstack([0, np.where(dts > 5 * np.median(dts))[0] + 1, len(time)])

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -134,9 +134,14 @@ def test_poscorr_smooth():
         poscorr2_binned,
     ) = machine._time_bin(npoints=100)
 
-    assert np.isclose(
-        poscorr1_smooth, np.nanmedian(machine.pos_corr1, axis=0), atol=1e-3
-    ).all()
-    assert np.isclose(
-        poscorr2_smooth, np.nanmedian(machine.pos_corr2, axis=0), atol=1e-3
-    ).all()
+    median_pc1 = np.nanmedian(machine.pos_corr1, axis=0)
+    median_pc2 = np.nanmedian(machine.pos_corr2, axis=0)
+    median_pc1 = (median_pc1 - median_pc1.mean()) / (
+        median_pc1.max() - median_pc1.mean()
+    )
+    median_pc2 = (median_pc2 - median_pc2.mean()) / (
+        median_pc2.max() - median_pc2.mean()
+    )
+
+    assert np.isclose(poscorr1_smooth, median_pc1, atol=1e-3).all()
+    assert np.isclose(poscorr2_smooth, median_pc2, atol=1e-3).all()

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -132,7 +132,7 @@ def test_poscorr_smooth():
         poscorr2_smooth,
         poscorr1_binned,
         poscorr2_binned,
-    ) = machine._time_bin(npoints=100)
+    ) = machine._time_bin(npoints=3)
 
     median_pc1 = np.nanmedian(machine.pos_corr1, axis=0)
     median_pc2 = np.nanmedian(machine.pos_corr2, axis=0)
@@ -145,3 +145,22 @@ def test_poscorr_smooth():
 
     assert np.isclose(poscorr1_smooth, median_pc1, atol=1e-3).all()
     assert np.isclose(poscorr2_smooth, median_pc2, atol=1e-3).all()
+
+
+@pytest.mark.remote_data
+def test_segment_time_model():
+    # testing segment with the current test dataset we have that only has 10 cadences
+    # isn't the best, but we can still do some sanity checks.
+    machine = TPFMachine.from_TPFs(tpfs, apply_focus_mask=False, n_time_points=3)
+    machine.build_shape_model(plot=False)
+    # no segments
+    machine.build_time_model(split_time_model=False, downsample=True)
+    assert machine.time_model_w.shape[0] == machine.seg_splits.shape[0] - 1
+    assert machine.time_model_w.shape[0] == machine._time_masked.shape[0]
+
+    # need tighter knot spacing
+    machine.n_time_points = 2
+    # user defined segments
+    machine.build_time_model(split_time_model=[5], downsample=True)
+    assert machine.time_model_w.shape[0] == machine.seg_splits.shape[0] - 1
+    assert machine.time_model_w.shape[0] == machine._time_masked.shape[0]


### PR DESCRIPTION
This PR allows fitting different time models to light curve segments inside a quarter by using a common shape model and pixel lightcurve normalization.
It finds how many segments are in the quarter by finding discontinuities in the time data. Then iterates over these segments to build and fit time models accordingly.

The `build_time_model()` takes the `split_models` argument (boolean) to split or not by segments.
The `plot_time_model()` method takes the `segment` argument to select which segment to plot.

I fixed the downsampling in `_time_bin()` to capture the start/end of each segment.  This fix makes the one `pytest` fail. Need to see what's going on there.

TODO:
- [x] Maybe `split_models` argument could also accept an array of indexes for user-custom splits
- [x] Fix pytest fail for `_time_bin()`