### PR TITLE
[WIP-draft] Multi quarters API [do-NOT-merge]

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1048,9 +1048,6 @@ class Machine(object):
             radius=self.time_radius,
             spacing=self.cartesian_knot_spacing,
         )
-        # if self.seg_splits.shape[0] == 2 and segment == 0:
-        #     seg_mask = np.ones(time_binned.shape[0], dtype=bool)
-        # else:
         seg_mask = (time_binned[:, 0] >= time_original[self.seg_splits[segment]]) & (
             time_binned[:, 0] < time_original[self.seg_splits[segment + 1] - 1]
         )

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -950,6 +950,7 @@ class TPFMachine(Machine):
             dec,
             column,
             row,
+            tpfs,
             saturated_mask,
         )
 
@@ -1300,6 +1301,7 @@ def _preprocess(
     dec,
     column,
     row,
+    tpfs,
     saturated,
 ):
     """

--- a/src/psfmachine/utils.py
+++ b/src/psfmachine/utils.py
@@ -542,3 +542,21 @@ def threshold_bin(x, y, z, z_err=None, abs_thresh=10, bins=15, statistic=np.nanm
         np.hstack(new_z),
         np.hstack(new_z_err),
     )
+
+
+def get_breaks(time):
+    """
+    Finds discontinuity in the time array and return the break indexes.
+
+    Parameters
+    ----------
+    time : numpy.ndarray
+        Array with time values
+
+    Returns
+    -------
+    splits : numpy.ndarray
+        An array of indexes with the break positions
+    """
+    dts = np.diff(time)
+    return np.hstack([0, np.where(dts > 5 * np.median(dts))[0] + 1, len(time)])


### PR DESCRIPTION
This PR shows how to adapt the API to work with multi-quarter TPFS of the same sky group, e.g. TPFs of Kepler quarter 1, 5, 9. 
It includes a custom multi-quarter method (`_parse_multi_quarter_TPFs`) that uses masks to find shared TPF pixels between quarters, this is necessary because sometimes the target masks change between quarters. For now, we only used pixels that have data in all quarters, this can be improved in the future to keep pixels with missing quarters.

TODO:
- [ ] The pixel masks used to concatenate TPF quarters can be replaced by Pandas DataFrames and the `pd.merge` method, this could be faster and cleaner.
- [ ] Keep pixels with missing quarters. Using Pandas to merge TPFs could make this easier, but need to change the `machine` API to allow missing data. 

Note:
This PR uses #52, which adds the "segment" method to the time model fitting.