### PR TITLE
Fixing Issue #56 of duplicated pixels

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -1088,7 +1088,7 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
     sat_mask = []
     for tpf in tpfs:
         # Keplerish saturation limit
-        saturated = np.nanmax(tpf.flux, axis=0).T.value > 1.4e5
+        saturated = np.nanmax(tpf.flux, axis=0).T.value > 1.2e5
         saturated = np.hstack(
             (np.gradient(saturated.astype(float))[1] != 0) | saturated
         )

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -1125,8 +1125,6 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
 def _preprocess(
     flux,
     flux_err,
-    # pos_corr1,
-    # pos_corr2,
     unw,
     locs,
     ra,
@@ -1150,8 +1148,8 @@ def _preprocess(
         # Find bad pixels, including allowence for a bleed column.
         bad_pixels = np.vstack(
             [
-                np.hstack([column[saturated] + idx for idx in np.arange(-3, 3)]),
-                np.hstack([row[saturated] for idx in np.arange(-3, 3)]),
+                np.hstack([column[saturated] + idx for idx in np.arange(-1, 1)]),
+                np.hstack([row[saturated] for idx in np.arange(-1, 1)]),
             ]
         ).T
         # Find unique row/column combinations
@@ -1169,14 +1167,9 @@ def _preprocess(
     flux = np.asarray(flux)
     flux_err = np.asarray(flux_err)
 
-    # Finite pixels
+    # Finite and non-saturated pixels
     not_nan = np.isfinite(flux).all(axis=0)
-    # Unique Pixels
-    _, unique_pix = np.unique(locs, axis=1, return_index=True)
-    unique_pix = np.in1d(np.arange(len(ra)), unique_pix)
-    # No saturation and bleed columns
-
-    mask = not_nan & unique_pix & ~saturated
+    mask = not_nan & ~saturated
 
     locs = locs[:, mask]
     column = column[mask]
@@ -1185,9 +1178,20 @@ def _preprocess(
     dec = dec[mask]
     flux = flux[:, mask]
     flux_err = flux_err[:, mask]
-    # pos_corr1 = pos_corr1[:, mask]
-    # pos_corr2 = pos_corr2[:, mask]
     unw = unw[mask]
+
+    # Unique Pixels
+    _, unique_pix = np.unique(locs, axis=1, return_index=True)
+    unique_pix = np.in1d(np.arange(len(ra)), unique_pix)
+
+    locs = locs[:, unique_pix]
+    column = column[unique_pix]
+    row = row[unique_pix]
+    ra = ra[unique_pix]
+    dec = dec[unique_pix]
+    flux = flux[:, unique_pix]
+    flux_err = flux_err[:, unique_pix]
+    unw = unw[unique_pix]
 
     return (flux, flux_err, unw, locs, ra, dec, column, row)
 

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -1089,9 +1089,10 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
     for tpf in tpfs:
         # Keplerish saturation limit
         saturated = np.nanmax(tpf.flux, axis=0).T.value > 1.2e5
-        saturated = np.hstack(
-            (np.gradient(saturated.astype(float))[1] != 0) | saturated
-        )
+        # add 3 pixels before and after bleed column to be generous
+        for k in range(3):
+            saturated = (np.gradient(saturated.astype(float))[1] != 0) | saturated
+        saturated = np.hstack(saturated)
         sat_mask.append(np.hstack(saturated))
     sat_mask = np.hstack(sat_mask)
     pos_corr1, pos_corr2 = np.swapaxes(

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -24,18 +24,18 @@ def test_create_delta_sparse_arrays():
 
     # check for main attrs shape
     assert non_sparse_arr["time"].shape == (10,)
-    assert non_sparse_arr["flux"].shape == (10, 285)
-    assert non_sparse_arr["flux_err"].shape == (10, 285)
-    assert non_sparse_arr["column"].shape == (285,)
-    assert non_sparse_arr["row"].shape == (285,)
-    assert non_sparse_arr["ra"].shape == (285,)
-    assert non_sparse_arr["dec"].shape == (285,)
+    assert non_sparse_arr["flux"].shape == (10, 287)
+    assert non_sparse_arr["flux_err"].shape == (10, 287)
+    assert non_sparse_arr["column"].shape == (287,)
+    assert non_sparse_arr["row"].shape == (287,)
+    assert non_sparse_arr["ra"].shape == (287,)
+    assert non_sparse_arr["dec"].shape == (287,)
     assert non_sparse_arr["sources"].shape == (19, 13)
 
-    assert non_sparse_arr["dra"].shape == (19, 285)
-    assert non_sparse_arr["ddec"].shape == (19, 285)
-    assert non_sparse_arr["r"].shape == (19, 285)
-    assert non_sparse_arr["phi"].shape == (19, 285)
+    assert non_sparse_arr["dra"].shape == (19, 287)
+    assert non_sparse_arr["ddec"].shape == (19, 287)
+    assert non_sparse_arr["r"].shape == (19, 287)
+    assert non_sparse_arr["phi"].shape == (19, 287)
     # check dra ddec r and phi are numpy arrays
     assert isinstance(non_sparse_arr["dra"], np.ndarray)
     assert isinstance(non_sparse_arr["ddec"], np.ndarray)
@@ -62,10 +62,10 @@ def test_create_delta_sparse_arrays():
     assert isinstance(sparse_arr["r"], sparse.csr_matrix)
     assert isinstance(sparse_arr["phi"], sparse.csr_matrix)
     # check for non-zero values shape
-    assert sparse_arr["dra"].data.shape == (853,)
-    assert sparse_arr["ddec"].data.shape == (853,)
-    assert sparse_arr["r"].data.shape == (853,)
-    assert sparse_arr["phi"].data.shape == (853,)
+    assert sparse_arr["dra"].data.shape == (861,)
+    assert sparse_arr["ddec"].data.shape == (861,)
+    assert sparse_arr["r"].data.shape == (861,)
+    assert sparse_arr["phi"].data.shape == (861,)
 
     # compare sparse array vs numpy array values
     assert (non_sparse_arr["dra"][mask].value == sparse_arr["dra"].data).all()
@@ -85,7 +85,7 @@ def test_compute_aperture_photometry():
     )
     # compute max aperture
     machine.create_aperture_mask(percentile=0)
-    assert machine.aperture_mask.shape == (19, 285)
+    assert machine.aperture_mask.shape == (19, 287)
     # some sources way outside the TPF can have 0-size aperture
     assert (machine.aperture_mask.sum(axis=1) >= 0).all()
     assert machine.FLFRCSAP.shape == (19,)
@@ -104,7 +104,7 @@ def test_compute_aperture_photometry():
     assert (machine.FLFRCSAP[np.isfinite(machine.FLFRCSAP)] <= 1).all()
 
     machine.compute_aperture_photometry(aperture_size="optimal")
-    assert machine.aperture_mask.shape == (19, 285)
+    assert machine.aperture_mask.shape == (19, 287)
     # some sources way outside the TPF can have 0-size aperture
     assert (machine.aperture_mask.sum(axis=1) >= 0).all()
     # check aperture size is within range

--- a/tests/test_tpfmachine.py
+++ b/tests/test_tpfmachine.py
@@ -79,11 +79,16 @@ def test_parse_TPFs():
     assert np.isfinite(ra).all()
     assert np.isfinite(dec).all()
 
-    assert locs.shape == (2, 285)
-    assert ra.shape == (285,)
-    assert dec.shape == (285,)
-    assert flux.shape == (10, 285)
-    assert flux_err.shape == (10, 285)
+    assert locs.shape == (2, 287)
+    assert ra.shape == (287,)
+    assert dec.shape == (287,)
+    assert flux.shape == (10, 287)
+    assert flux_err.shape == (10, 287)
+
+    # cheking no duplicated pixels remain
+    _, unique_idx = np.unique(locs, axis=1, return_index=True)
+    unique_idx = np.in1d(np.arange(len(ra)), unique_idx)
+    assert (~unique_idx).sum() == 0
 
     sources = _get_coord_and_query_gaia(tpfs)
 


### PR DESCRIPTION
This PR fixes the duplicated pixel bug.
Here some examples of new behaviero:

![image](https://user-images.githubusercontent.com/10449555/160220212-f2043e9a-c10a-4843-86ab-9fda1a3a2176.png)
![image](https://user-images.githubusercontent.com/10449555/160220205-e5abcdcd-0dfa-42b3-92b3-c14837cfccf9.png)

Note: 
- I had to duplicate the masking steps to do nan & saturated pixel masking first, and then mask duplicated pixels.
- Pytest had to be updated to match the correct number of pixels. 
- I also included an extra test to check no duplicated pixels remain and that all valid pixels are kept only once after preprocess 

This solves #56 