### PR TITLE
K2 C9 fix

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -1,7 +1,6 @@
 """Subclass of `Machine` that Specifically work with TPFs"""
 import os
 import logging
-import warnings
 import numpy as np
 import lightkurve as lk
 from astropy.coordinates import SkyCoord, match_coordinates_sky
@@ -128,8 +127,8 @@ class TPFMachine(Machine):
             keys; "column", "row", and "flux".
         """
         if not self.tpf_meta["mission"][0].lower() in ["kepler", "k2", "ktwo"]:
-            log.info(
-                "Warning: Background fitting is a Kepler only tool, "
+            log.warning(
+                "Background fitting is a Kepler only tool, "
                 "then no background model will be fitted."
             )
             return
@@ -1086,7 +1085,7 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
     if renormalize_tpf_bkg:
         # we check if TPF data is bkg subtracted
         if tpfs[0].mission == "K2":
-            warnings.warn(
+            log.warning(
                 "`kbackground` currently does not support K2 data. We recommend setting"
                 " `renormalize_tpf_bkg=False` and use the pipeline background model."
             )
@@ -1099,7 +1098,7 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
             )
             flux += flux_bkg
         else:
-            warnings.warn(
+            log.warning(
                 "TPFs are not background subtracted, will initialize as default."
             )
 

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -1085,6 +1085,11 @@ def _parse_TPFs(tpfs, renormalize_tpf_bkg=True, **kwargs):
     )
     if renormalize_tpf_bkg:
         # we check if TPF data is bkg subtracted
+        if tpfs[0].mission == "K2":
+            warnings.warn(
+                "`kbackground` currently does not support K2 data. We recommend setting"
+                " `renormalize_tpf_bkg=False` and use the pipeline background model."
+            )
         if fits.getheader(tpfs[0].path, ext=1)["BACKAPP"]:
             flux_bkg = np.hstack(
                 [

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -54,7 +54,7 @@ class TPFMachine(Machine):
         tpf_meta=None,
         time_corrector="pos_corr",
         cartesian_knot_spacing="sqrt",
-        bkg_substracted=True,
+        bkg_subtracted=True,
     ):
         super().__init__(
             time=time,
@@ -95,7 +95,7 @@ class TPFMachine(Machine):
         self.tpf_meta = tpf_meta
         self.time_corrector = time_corrector
         self.cartesian_knot_spacing = cartesian_knot_spacing
-        self.bkg_substracted = bkg_substracted
+        self.bkg_subtracted = bkg_subtracted
 
     def __repr__(self):
         return f"TPFMachine (N sources, N times, N pixels): {self.shape}"
@@ -179,7 +179,7 @@ class TPFMachine(Machine):
         )
 
         # remove background when necessary, this is done just once
-        if not self.bkg_substracted:
+        if not self.bkg_subtracted:
             bkg_mask = ~np.asarray(
                 (self.source_mask.todense()).sum(axis=0).astype(bool)
             ).ravel()
@@ -188,7 +188,7 @@ class TPFMachine(Machine):
             self.flux -= self.bkg_estimator.model[:, self.pixels_in_tpf]
             self.flux -= np.median(self.flux[:, bkg_mask])
             # set bkg subs flag so this step happens only one time
-            self.bkg_substracted = True
+            self.bkg_subtracted = True
 
         if plot:
             self.bkg_estimator.plot()
@@ -1001,7 +1001,7 @@ class TPFMachine(Machine):
             pos_corr2=pos_corr2,
             tpf_meta=tpf_meta,
             time_mask=time_mask,
-            bkg_substracted=not renormalize_tpf_bkg,
+            bkg_subtracted=not renormalize_tpf_bkg,
             **kwargs,
         )
 


### PR DESCRIPTION
This PR improves `_parse_TPFs()` to work when `poscorrs` values are `NaNs` and to check if the TPF data is background-subtracted before adding the background data when `renormalize_tpf_bkg=True`. 