### PR TITLE
non-neg pixel flux option and better xknotspacing

### DIFF
--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -200,10 +200,8 @@ class TPFMachine(Machine):
             self.bkg_flux,
             mask=self.bkg_pixel_mask,
             tknotspacing=4,
-            # this should take into account the maximum space between bkg pixels in row
-            xknotspacing=np.maximum(
-                np.diff(np.unique(self.bkg_row[self.bkg_pixel_mask])).max() / 2, 6
-            ),
+            # this takes into account the maximum space between bkg pixels in row
+            xknotspacing=16,
         )
 
         # remove background when necessary, this is done just once

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -100,7 +100,9 @@ class TPFMachine(Machine):
     def __repr__(self):
         return f"TPFMachine (N sources, N times, N pixels): {self.shape}"
 
-    def remove_background_model(self, plot=False, data_augment=None):
+    def remove_background_model(
+        self, plot=False, data_augment=None, zero_centered=True
+    ):
         """
         Function to fit and remove the background signal of the TPF stack using
         `kbackground` package. This is a Kepler/K2 specific tool.
@@ -126,6 +128,9 @@ class TPFMachine(Machine):
             augment the background pixels. This argument is useful to include Kepler's
             background pixels from the mission. The dictionary has to have the following
             keys; "column", "row", and "flux".
+        zero_centered : boolean
+            If True the pixel background level will be zero centered. If False pixels
+            will be positive.
         """
         if not self.tpf_meta["mission"][0].lower() in ["kepler", "k2", "ktwo"]:
             log.warning(
@@ -195,20 +200,28 @@ class TPFMachine(Machine):
             self.bkg_flux,
             mask=self.bkg_pixel_mask,
             tknotspacing=4,
-            xknotspacing=6,
+            # this should take into account the maximum space between bkg pixels in row
+            xknotspacing=np.maximum(
+                np.diff(np.unique(self.bkg_row[self.bkg_pixel_mask])).max() / 2, 6
+            ),
         )
 
         # remove background when necessary, this is done just once
         if not self.bkg_subtracted:
-            bkg_mask = ~np.asarray(
-                (self.source_mask.todense()).sum(axis=0).astype(bool)
-            ).ravel()
             # remove bkg and median value (kbackground fits the median-normalized
             # background)
             self.flux -= self.bkg_estimator.model[:, self.pixels_in_tpf]
-            self.flux -= np.median(self.flux[:, bkg_mask])
+            # to avoid negative fluxes
+            self.bkg_median_level = np.median(
+                self.flux[:, self.bkg_pixel_mask[self.pixels_in_tpf]]
+            )
+            self.flux -= self.bkg_median_level
             # set bkg subs flag so this step happens only one time
             self.bkg_subtracted = True
+            if not zero_centered:
+                zp = np.abs(self.flux.min())
+                self.bkg_median_level += zp
+                self.flux += zp
 
         if plot:
             self.bkg_estimator.plot()


### PR DESCRIPTION
This PR improves the knot spacing selection for the background model and adds the option to have positive flux values or zero-centered values for the background.

1. `xknotspacing=6` is a good value when the set of pixels is 'dense' in the row axis but can produce wrong bkg models when it is not as shown here: 
![image](https://user-images.githubusercontent.com/10449555/176960948-e551b048-49f0-424a-a787-b2669f202d3a.png)
which shows significant gaps between bkg pixel data.
![image](https://user-images.githubusercontent.com/10449555/176961124-5300d1af-1a4a-473d-82c6-ef096b40cd6c.png)
this is a random selection of bkg pixels

- The solution is to make `xknotspacing` aware of the maximum gap between bkg pixels in the row direction. Here the same example but using half of the maximum gap (16)
![image](https://user-images.githubusercontent.com/10449555/176961276-44c6a723-2eeb-4b39-928e-77e53e1e310c.png)
![image](https://user-images.githubusercontent.com/10449555/176962107-9dc30f17-3c4d-4608-a872-15e8b5eacc72.png)

Of course, this sacrifices resolution in the bkg model but should be a good compromise for these cases.

2. An optional argument to make the bkg subtracted flux non-negative, but `machine` in general assumes that bkg pixels are zero centered, therefore using this argument could lead to wrong shape models. Default is set to zero-centered values.
