### PR TITLE
Adds a limiting magnitude for sources to be considered as contaminants

### DIFF
--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -139,6 +139,8 @@ class Machine(object):
             the design matrix, options are "linear" or "sqrt".
         quiet: booleans
             Quiets TQDM progress bars.
+        contaminant_mag_limit: float
+          The limiting magnitude at which a sources is considered as contaminant
         """
 
         if not isinstance(sources, pd.DataFrame):
@@ -167,7 +169,7 @@ class Machine(object):
         self.cartesian_knot_spacing = "sqrt"
         # disble tqdm prgress bar when running in HPC
         self.quiet = False
-        self.cont_mag_limit = None
+        self.contaminant_mag_limit = None
 
         if time_mask is None:
             self.time_mask = np.ones(len(time), bool)
@@ -565,17 +567,13 @@ class Machine(object):
         """
         creates a mask of shape nsources x npixels where targets are not contaminated.
         This mask is used to select pixels to build the PSF model.
-
-        Parameters
-        ----------
-        mag_limit: float
-          The magnitude value at which a sources is considered as contaminant
         """
 
         # we flag sources fainter than mag_limit as non-contaminant
-        if isinstance(self.cont_mag_limit, (float, int)):
+        if isinstance(self.contaminant_mag_limit, (float, int)):
             aux = self.source_mask.multiply(
-                self.sources.phot_g_mean_mag.values[:, None] < self.cont_mag_limit
+                self.sources.phot_g_mean_mag.values[:, None]
+                < self.contaminant_mag_limit
             )
             aux.eliminate_zeros()
             self.uncontaminated_source_mask = aux.multiply(

--- a/src/psfmachine/machine.py
+++ b/src/psfmachine/machine.py
@@ -1267,7 +1267,6 @@ class Machine(object):
             ylim=(0, radius),
             yticks=np.linspace(0, radius, 5, dtype=int),
         )
-
         im = ax[1, 0].scatter(
             dx,
             dy,

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -97,6 +97,7 @@ class TPFMachine(Machine):
         self.cartesian_knot_spacing = cartesian_knot_spacing
         self.bkg_subtracted = bkg_subtracted
         # limiting mag values to consider contamination for kepler & tess
+        # hardcoded values to work with kepler
         if self.nsources / self.npixels > 0.2:
             if self.tpf_meta["mission"].lower() == "kepler":
                 self.cont_mag_limit = 17.5

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -100,11 +100,15 @@ class TPFMachine(Machine):
         # hardcoded values to work with kepler
         if self.nsources / self.npixels > 0.2:
             if self.tpf_meta["mission"][0].lower() == "kepler":
-                self.cont_mag_limit = 17.5
+                self.contaminant_mag_limit = 17.5
             elif self.tpf_meta["mission"][0].lower() == "tess":
-                self.cont_mag_limit = 17
+                self.contaminant_mag_limit = 17
             else:
-                self.cont_mag_limit = 18
+                self.contaminant_mag_limit = 18
+            log.warning(
+                "Region is too crowded (nsources/npixels > 0.2), setting limiting "
+                f"magnitude to {self.contaminant_mag_limit} for contaminant sources."
+            )
 
     def __repr__(self):
         return f"TPFMachine (N sources, N times, N pixels): {self.shape}"

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -98,11 +98,12 @@ class TPFMachine(Machine):
         self.bkg_subtracted = bkg_subtracted
         # limiting mag values to consider contamination for kepler & tess
         # hardcoded values to work with kepler
+        # 0.2 seems ok for TESS
         if self.nsources / self.npixels > 0.2:
             if self.tpf_meta["mission"][0].lower() == "kepler":
                 self.contaminant_mag_limit = 17.5
             elif self.tpf_meta["mission"][0].lower() == "tess":
-                self.contaminant_mag_limit = 17
+                self.contaminant_mag_limit = 16
             else:
                 self.contaminant_mag_limit = 18
             log.warning(

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -99,9 +99,9 @@ class TPFMachine(Machine):
         # limiting mag values to consider contamination for kepler & tess
         # hardcoded values to work with kepler
         if self.nsources / self.npixels > 0.2:
-            if self.tpf_meta["mission"].lower() == "kepler":
+            if self.tpf_meta["mission"][0].lower() == "kepler":
                 self.cont_mag_limit = 17.5
-            elif self.tpf_meta["mission"].lower() == "tess":
+            elif self.tpf_meta["mission"][0].lower() == "tess":
                 self.cont_mag_limit = 17
             else:
                 self.cont_mag_limit = 18
@@ -219,7 +219,7 @@ class TPFMachine(Machine):
             # background)
             self.flux -= self.bkg_estimator.model[:, self.pixels_in_tpf]
             # to avoid negative fluxes
-            self.bkg_median_level = np.median(
+            self.bkg_median_level = np.nanmedian(
                 self.flux[:, self.bkg_pixel_mask[self.pixels_in_tpf]]
             )
             self.flux -= self.bkg_median_level
@@ -651,8 +651,10 @@ class TPFMachine(Machine):
             raise ValueError("File format not suported. Please provide a FITS file.")
 
         # create source mask and uncontaminated pixel mask
-        self._get_source_mask()
-        self._get_uncontaminated_pixel_mask()
+        if not hasattr(self, "source_mask"):
+            self._get_source_mask()
+        if not hasattr(self, "uncontaminated_source_mask"):
+            self._get_uncontaminated_pixel_mask()
 
         # open file
         hdu = fits.open(input)

--- a/src/psfmachine/tpf.py
+++ b/src/psfmachine/tpf.py
@@ -96,6 +96,14 @@ class TPFMachine(Machine):
         self.time_corrector = time_corrector
         self.cartesian_knot_spacing = cartesian_knot_spacing
         self.bkg_subtracted = bkg_subtracted
+        # limiting mag values to consider contamination for kepler & tess
+        if self.nsources / self.npixels > 0.2:
+            if self.tpf_meta["mission"].lower() == "kepler":
+                self.cont_mag_limit = 17.5
+            elif self.tpf_meta["mission"].lower() == "tess":
+                self.cont_mag_limit = 17
+            else:
+                self.cont_mag_limit = 18
 
     def __repr__(self):
         return f"TPFMachine (N sources, N times, N pixels): {self.shape}"


### PR DESCRIPTION
This PR modifies the following method:

- `machine._get_uncontaminated_sources()` to include a limit magnitude at which sources are considered as contaminants. 
- this limiting magnitude is 17.5 for Kepler data and it is applied when working with crowded regions defined as `n_sources / n_pixels > 0.2`. 